### PR TITLE
feat: Enable logging colors for easier human output parsing

### DIFF
--- a/matterbridge.go
+++ b/matterbridge.go
@@ -74,7 +74,7 @@ func setupLogger() *logrus.Logger {
 		Out: os.Stdout,
 		Formatter: &prefixed.TextFormatter{
 			PrefixPadding: 13,
-			DisableColors: true,
+			DisableColors: false,
 		},
 		Level: logrus.InfoLevel,
 	}
@@ -82,7 +82,7 @@ func setupLogger() *logrus.Logger {
 		logger.SetReportCaller(true)
 		logger.Formatter = &prefixed.TextFormatter{
 			PrefixPadding: 13,
-			DisableColors: true,
+			DisableColors: false,
 			FullTimestamp: false,
 
 			CallerFormatter: func(function, file string) string {


### PR DESCRIPTION
Why were we not doing that before? Is there a problem i'm unaware of? Is it because of some weird supported platform such as Windows?