### PR TITLE
cli: Add "-nocolor" flag to disable colored ouptut

### DIFF
--- a/matterbridge.go
+++ b/matterbridge.go
@@ -21,6 +21,7 @@ var (
 	flagDebug   = flag.Bool("debug", false, "enable debug")
 	flagVersion = flag.Bool("version", false, "show version")
 	flagGops    = flag.Bool("gops", false, "enable gops agent")
+	flagNoColor = flag.Bool("nocolor", false, "disable colored logs")
 )
 
 func main() {
@@ -74,7 +75,7 @@ func setupLogger() *logrus.Logger {
 		Out: os.Stdout,
 		Formatter: &prefixed.TextFormatter{
 			PrefixPadding: 13,
-			DisableColors: false,
+			DisableColors: *flagNoColor,
 		},
 		Level: logrus.InfoLevel,
 	}
@@ -82,7 +83,7 @@ func setupLogger() *logrus.Logger {
 		logger.SetReportCaller(true)
 		logger.Formatter = &prefixed.TextFormatter{
 			PrefixPadding: 13,
-			DisableColors: false,
+			DisableColors: *flagNoColor,
 			FullTimestamp: false,
 
 			CallerFormatter: func(function, file string) string {


### PR DESCRIPTION
I was thinking when updating the changelog. Maybe some people do still use systems where colored output messes with eg. log parsing. So it's probably better to include a flag to disable it in case they need it.

`matterbridge -nocolor` disables colored log output.

I didn't update the changelog in this PR because there's already a parallel PR about this. But we should definitely make sure we update the changelog when reviewing PRs :)