### PR TITLE
XMPP: Added downloading files from the BOSH server

### DIFF
--- a/bridge/xmpp/helpers.go
+++ b/bridge/xmpp/helpers.go
@@ -2,6 +2,8 @@ package bxmpp
 
 import (
 	"regexp"
+	"strings"
+	"net/url"
 
 	"github.com/matterbridge-org/matterbridge/bridge/config"
 )
@@ -27,4 +29,17 @@ func (b *Bxmpp) cacheAvatar(msg *config.Message) string {
 		b.avatarMap[msg.UserID] = fi.SHA
 	}
 	return ""
+}
+
+func (b *Bxmpp) isUrl(str string, boshUrl string) bool {
+	if boshUrl == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(str, boshUrl) {
+		return false
+	}
+
+	parsedUrl, err := url.Parse(str)
+	return err == nil && parsedUrl.Scheme != "" && parsedUrl.Host != ""
 }


### PR DESCRIPTION
(It's required to specify the URL of the BOSH server to properly recognise the URL)

This feature allows to make re-uploading of BOSH-uploaded files to other messengers directly. So, they are received nicely everywhere that supports direct file uploads.