### PR TITLE
Use new helpers for Matrix authenticate media

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
     the return code is not 200 to avoid saving trash data ([#20](https://github.com/matterbridge-org/matterbridge/pull/20))
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
+  - image attachments are now send as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
 
 ## Upstream
 


### PR DESCRIPTION
This is based on https://github.com/42wim/matterbridge/pull/2228
and #58 

Thanks to their original contributors for the hard work!