### PR TITLE
Fixed minor markdown mistake in the Discord settings's documentation

### DIFF
--- a/docs/protocols/discord/settings.md
+++ b/docs/protocols/discord/settings.md
@@ -112,7 +112,8 @@ for each gateway and not in the account configuration.
 - Format: *string*
 - Example:
   ```toml
-  `WebhookURL="Yourwebhooktokenhere"` 
+  WebhookURL="Yourwebhooktokenhere"
+  ```
 
 ## AutoWebhooks
 
@@ -128,4 +129,6 @@ Setting: OPTIONAL \
 Format: boolean \
 Example:
 
-`AutoWebhooks=true`
+  ```toml
+  AutoWebhooks=true
+  ```


### PR DESCRIPTION
Just a small missing of the closure tag causes entire code block below being failed.