### PR TITLE
Build with CGO_ENABLED=1 to get sqllite driver working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN go mod download
 
 COPY . /go/src/matterbridge
 
-RUN apk --no-cache add git
+RUN apk --no-cache add git gcc musl-dev
 RUN cd /go/src/matterbridge && \
-    CGO_ENABLED=0 go build -tags goolm -ldflags "-X github.com/matterbridge-org/matterbridge/version.GitHash=$(git log --pretty=format:'%h' -n 1)" -o /bin/matterbridge
+    CGO_ENABLED=1 go build -tags goolm -ldflags "-X github.com/matterbridge-org/matterbridge/version.GitHash=$(git log --pretty=format:'%h' -n 1)" -o /bin/matterbridge
 
 FROM alpine
 RUN apk --no-cache add ca-certificates mailcap


### PR DESCRIPTION

Build the Dockerimage CGO_ENABLED=1  to enable the sqllite driver working which is needed for bridging encrypted matrix rooms. 

Fixes: https://github.com/matterbridge-org/matterbridge/issues/117 