### PR TITLE
discord: Workaround replies not being allowed to use webhooks.

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -35,19 +35,20 @@ const (
 const ParentIDNotFound = "msg-parent-not-found"
 
 type Message struct {
-	Text      string    `json:"text"`
-	Channel   string    `json:"channel"`
-	Username  string    `json:"username"`
-	UserID    string    `json:"userid"` // userid on the bridge
-	Avatar    string    `json:"avatar"`
-	Account   string    `json:"account"`
-	Event     string    `json:"event"`
-	Protocol  string    `json:"protocol"`
-	Gateway   string    `json:"gateway"`
-	ParentID  string    `json:"parent_id"`
-	Timestamp time.Time `json:"timestamp"`
-	ID        string    `json:"id"`
-	Extra     map[string][]interface{}
+	Text             string    `json:"text"`
+	Channel          string    `json:"channel"`
+	Username         string    `json:"username"`
+	OriginalUsername string    `json:"original_username"` // Username before RemoteNickFormat gets applied
+	UserID           string    `json:"userid"`            // userid on the bridge
+	Avatar           string    `json:"avatar"`
+	Account          string    `json:"account"`
+	Event            string    `json:"event"`
+	Protocol         string    `json:"protocol"`
+	Gateway          string    `json:"gateway"`
+	ParentID         string    `json:"parent_id"`
+	Timestamp        time.Time `json:"timestamp"`
+	ID               string    `json:"id"`
+	Extra            map[string][]interface{}
 }
 
 func (m Message) ParentNotFound() bool {

--- a/bridge/discord/webhook.go
+++ b/bridge/discord/webhook.go
@@ -33,7 +33,7 @@ func (b *Bdiscord) maybeGetLocalAvatar(msg *config.Message) string {
 			continue
 		}
 
-		member, err := b.getGuildMemberByNick(msg.Username)
+		member, err := b.getGuildMemberByNick(msg.OriginalUsername)
 		if err != nil {
 			return ""
 		}
@@ -51,7 +51,7 @@ func (b *Bdiscord) webhookSendTextOnly(msg *config.Message, channelID string) (s
 			channelID,
 			&discordgo.WebhookParams{
 				Content:         msgPart,
-				Username:        msg.Username,
+				Username:        msg.OriginalUsername,
 				AvatarURL:       msg.Avatar,
 				AllowedMentions: b.getAllowedMentions(),
 			},
@@ -81,7 +81,7 @@ func (b *Bdiscord) webhookSendFilesOnly(msg *config.Message, channelID string) e
 		_, err := b.transmitter.Send(
 			channelID,
 			&discordgo.WebhookParams{
-				Username:        msg.Username,
+				Username:        msg.OriginalUsername,
 				AvatarURL:       msg.Avatar,
 				Files:           []*discordgo.File{&file},
 				Content:         content,
@@ -137,8 +137,8 @@ func (b *Bdiscord) handleEventWebhook(msg *config.Message, channelID string) (st
 	}
 
 	// discord username must be [0..32] max
-	if len(msg.Username) > 32 {
-		msg.Username = msg.Username[0:32]
+	if len(msg.OriginalUsername) > 32 {
+		msg.OriginalUsername = msg.OriginalUsername[0:32]
 	}
 
 	if msg.ID != "" {
@@ -155,7 +155,7 @@ func (b *Bdiscord) handleEventWebhook(msg *config.Message, channelID string) (st
 			// TODO: Optimize away noop-updates of un-edited messages
 			editErr = b.transmitter.Edit(channelID, msgIds[i], &discordgo.WebhookParams{
 				Content:         msgParts[i],
-				Username:        msg.Username,
+				Username:        msg.OriginalUsername,
 				AllowedMentions: b.getAllowedMentions(),
 			})
 			if editErr != nil {

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 ## New Features
 
 - general
+  - The original username of a message is carried internally beside the version modified by `RemoteNickFormat` ([#135](https://github.com/matterbridge-org/matterbridge/pull/135)) for bridges that can make use of it.
   - matterbridge output now colors log level for easier log reading ([#25](https://github.com/matterbridge-org/matterbridge/pull/25))
   - new HTTP helpers are common to all bridges, and allow overriding specific settings ([#59](https://github.com/matterbridge-org/matterbridge/pull/59))
   - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
@@ -41,6 +42,7 @@
   - Can now upload files from bytes in addition to sharing attachement URLs ([#23](https://github.com/matterbridge-org/matterbridge/pull/23/))
   - Can now receive and download OOB attachments from XMPP channels to share with other bridges ([#23](https://github.com/matterbridge-org/matterbridge/pull/23/))
 - discord
+  - Messages that use the username-spoofing webhook API always use the original username instead of applying `RemoteNickFormat`.
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
   - whatsapp
     - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings

--- a/docs/protocols/discord/README.md
+++ b/docs/protocols/discord/README.md
@@ -32,6 +32,8 @@ See [account.md](account.md).
 
 [Creating a message](https://discordapp.com/developers/docs/resources/channel#create-message) via a user's API token (the basic configuration above) only lets Matterbridge post with the user/avatar that generated the token. But [executing a webhook](https://discordapp.com/developers/docs/resources/webhook#execute-webhook) can set any username and avatar URL.
 
+However, _replies_ [cannot spo](https://github.com/discord/discord-api-docs/issues/2251)[oof usernames](https://github.com/discord/discord-api-docs/discussions/3282), so unfortunately replies always fall back to embedding the sender's username with `RemoteNickFormat`.
+
 If you grant the bot the "Manage Webhooks" permission, it will automatically load and create webhooks in every bridged channel. You can even grant that permission on specific channels, if you don't want to give it global permission.
 
 1. Server Settings -> Roles

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -476,6 +476,7 @@ func (gw *Gateway) SendMessage(
 
 	msg.Channel = channel.Name
 	msg.Avatar = gw.modifyAvatar(rmsg, dest)
+	msg.OriginalUsername = msg.Username
 	msg.Username = gw.modifyUsername(rmsg, dest)
 
 	// exclude file delete event as the msg ID here is the native file ID that needs to be deleted


### PR DESCRIPTION
Discord does not allow replies to be created via webhook
- https://github.com/discord/discord-api-docs/issues/2251
- https://github.com/discord/discord-api-docs/discussions/3282

this means that, in a standard setup where `Autowebhooks=true` is on, a conversation that interleaves replies cannot have the bridge masquerade the username on the replies. Since the default is `RemoteNickFormat="{NICK}"`, this leads to messages running together with the sender name like

<img width="224" height="144" alt="image" src="https://github.com/user-attachments/assets/bd195178-7cee-41c0-8857-189c7e0c9815" />

This is a hacky workaround. It just rewrites the username as if `RemoteNickFormat="<{NICK}> "`, with a space.

<img width="244" height="155" alt="image" src="https://github.com/user-attachments/assets/a3e12ffc-9a6b-4b53-9e8a-4e9d40fac1b6" />

I am not happy with it. I am very open to brainstorming other fixes.

Personally, this was motivated by https://github.com/matterbridge-org/matterbridge/pull/134; with XMPP replies working now this gap was thrown back in our faces. Previously we just didn't have replies so we never noticed.