### PR TITLE
matrix: check scheme in Server before use it to replace mxc

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -768,7 +768,12 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 	// Matrix downloads now have to be authenticated with an access token
 	// See https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3916-authentication-for-media.md
 	// Also see: https://github.com/matterbridge-org/matterbridge/issues/36
-	url = strings.ReplaceAll(url, "mxc://", b.GetString("Server")+"/_matrix/client/v1/media/download/")
+	default_scheme := ""
+	server := b.GetString("Server")
+	if !strings.Contains(server, "://") {
+		default_scheme = "https://"
+	}
+	url = strings.ReplaceAll(url, "mxc://", default_scheme + server + "/_matrix/client/v1/media/download/")
 
 	if info, ok = content.Raw["info"].(map[string]any); !ok {
 		return fmt.Errorf("info isn't a %T", info)


### PR DESCRIPTION
make sure we include default https:// scheme if the "Server" configuration variable don't contain a scheme during replacing mxc:// to download media content