### PR TITLE
fix: whatsappmulti is built unless `nowhatsappmulti` build tag is passed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,7 @@
 - general
   - matterbridge output now colors log level for easier log reading ([#25](https://github.com/matterbridge-org/matterbridge/pull/25))
   - new HTTP helpers are common to all bridges, and allow overriding specific settings ([#59](https://github.com/matterbridge-org/matterbridge/pull/59))
-  - matterbridge is now built with whatsappmulti backend enabled by default
+  - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
   - Docker images are now automatically built and published to `ghcr.io/matterbridge-org/matterbridge` ([#86](https://github.com/matterbridge-org/matterbridge/pull/86))
 - mastodon
   - Add new Mastodon bridge ([#14](https://github.com/matterbridge-org/matterbridge/pull/14)/[#16](https://github.com/matterbridge-org/matterbridge/pull/16), thanks @lil5)

--- a/gateway/bridgemap/bwhatsappmulti.go
+++ b/gateway/bridgemap/bwhatsappmulti.go
@@ -1,4 +1,4 @@
-//go:build !whatsappmulti
+//go:build !nowhatsappmulti
 
 package bridgemap
 


### PR DESCRIPTION
As discovered in #147, passing the `whatsappmulti` build tag actually prevents it from being compiled, oops.