### PR TITLE
Add support for socket mode Events API for Slack bridge

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -9,6 +9,8 @@ import (
 	"github.com/matterbridge-org/matterbridge/bridge/config"
 	"github.com/matterbridge-org/matterbridge/bridge/helper"
 	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 )
 
 // ErrEventIgnored is for events that should be ignored
@@ -19,9 +21,12 @@ func (b *Bslack) handleSlack() {
 	if b.GetString(incomingWebhookConfig) != "" && b.GetString(tokenConfig) == "" {
 		b.Log.Debugf("Choosing webhooks based receiving")
 		go b.handleMatterHook(messages)
+	} else if b.GetString(appTokenConfig) != "" && b.GetString(tokenConfig) != "" {
+		b.Log.Debugf("Choosing socket mode Events API based receiving")
+		go b.handleSlackClientEAPI(messages)
 	} else {
-		b.Log.Debugf("Choosing token based receiving")
-		go b.handleSlackClient(messages)
+		b.Log.Debugf("Choosing RTM based receiving")
+		go b.handleSlackClientRTM(messages)
 	}
 	time.Sleep(time.Second)
 	b.Log.Debug("Start listening for Slack messages")
@@ -47,64 +52,174 @@ func (b *Bslack) handleSlack() {
 	}
 }
 
-func (b *Bslack) handleSlackClient(messages chan *config.Message) {
+// handleSlackClientEAPI handle slack events coming from socket mode Event API
+func (b *Bslack) handleSlackClientEAPI(messages chan *config.Message) {
+	b.Log.Warn("Socket mode Events API is currently WORK IN PROGRESS")
+
+	for sockEvt := range b.smc.Events {
+		b.Log.Debugf("== Received socket event: %#v", sockEvt)
+
+		switch sockEvt.Type {
+		case socketmode.EventTypeConnecting:
+			b.Log.Info("Connecting to Slack with socket mode")
+		case socketmode.EventTypeConnectionError:
+			b.Log.Error("Socket mode connection failed")
+		case socketmode.EventTypeConnected:
+			b.Log.Info("Socket mode connected")
+			si, err := b.sc.AuthTest()
+			if err != nil {
+				b.Log.Errorf("Slack AuthTest failed %#v", err)
+				continue
+			}
+			b.actingUserID = si.UserID
+			b.actingUserName = si.User
+			b.channels.populateChannels(true)
+			b.users.populateUsers(true)
+		case socketmode.EventTypeHello:
+			appID := sockEvt.Request.ConnectionInfo.AppID
+			b.Log.Debugf("Hello received, AppID %v", appID)
+		case socketmode.EventTypeInvalidAuth:
+			b.Log.Fatalf("Invalid Token %#v", *sockEvt.Request)
+
+		case socketmode.EventTypeEventsAPI:
+			oevt, ok := sockEvt.Data.(slackevents.EventsAPIEvent)
+			if !ok {
+				b.Log.Debugf("Ignored %#v", sockEvt)
+				continue
+			}
+			// you MUST ack event
+			b.smc.Ack(*sockEvt.Request)
+
+			b.Log.Debugf("Received event: %v %#v; inner: %#v", oevt.Type, oevt.Data, oevt.InnerEvent)
+
+			// CallbackEvent is more or less the only meaningful type of outer event
+			if oevt.Type != slackevents.CallbackEvent {
+				b.smc.Debugf("unsupported Events API event type %s received", oevt.Type)
+				continue
+			}
+
+			b.handleInnerEventEAPI(oevt.InnerEvent, messages)
+
+		case socketmode.EventTypeSlashCommand, socketmode.EventTypeInteractive:
+			// we don't expect these events to show up here but it's a valid one
+			// ack it properly and do nothing else
+			b.Log.Debugf("Skip unsupported event type %s", sockEvt.Type)
+			b.smc.Ack(*sockEvt.Request)
+
+		default:
+			// some of the events come from the socket mode client itself and are not a part of events api
+			// all event types that must be acked are already handled by above cases
+			// no need to blindly ack them here
+			b.Log.Debugf("Unhandled socket event: %T", sockEvt)
+		}
+	}
+}
+
+func (b *Bslack) handleInnerEventEAPI(ievt slackevents.EventsAPIInnerEvent, messages chan *config.Message) {
+	switch ev := ievt.Data.(type) {
+	case *slackevents.MessageEvent:
+		if b.skipMessageEventEAPI(ev) {
+			b.Log.Debugf("Skipped message: %#v", ev)
+			return
+		}
+		rmsg, err := b.handleMessageEventEAPI(ev)
+		if err != nil {
+			b.Log.Errorf("%#v", err)
+			return
+		}
+		messages <- rmsg
+
+	case *slackevents.FileDeletedEvent:
+		rmsg, err := b.handleFileDeleted(ev.FileID)
+		if err != nil {
+			b.Log.Warnf("%#v", err)
+			return
+		}
+		messages <- rmsg
+
+	case *slackevents.MemberJoinedChannelEvent:
+		b.Log.Debugf("user %q joined to channel %q", ev.User, ev.Channel)
+		// data in event contains only IDs
+		ch, err := b.sc.GetConversationInfo(&slack.GetConversationInfoInput{
+			ChannelID: ev.Channel,
+		})
+		if err != nil {
+			b.Log.Errorf("GetConversationInfo failed %v", err)
+			return
+		}
+		b.channels.registerChannel(*ch)
+		b.users.populateUser(ev.User)
+
+	case *slackevents.UserChangeEvent:
+		b.users.invalidateUser(ev.User.ID)
+	}
+}
+
+// handleSlackClientRTM handle slack events coming from legacy RTM system
+// this is an event dispatch board, it might not be a good idea to atomize the tasks to handle events
+//
+//nolint:gocyclo,funlen
+func (b *Bslack) handleSlackClientRTM(messages chan *config.Message) {
 	for msg := range b.rtm.IncomingEvents {
 		if msg.Type != sUserTyping && msg.Type != sHello && msg.Type != sLatencyReport {
 			b.Log.Debugf("== Receiving event %#v", msg.Data)
 		}
 		switch ev := msg.Data.(type) {
-		case *slack.UserTypingEvent:
-			if !b.GetBool("ShowUserTyping") {
-				continue
-			}
+		case *slack.UserTypingEvent: // no equivalent in EAPI
 			rmsg, err := b.handleTypingEvent(ev)
 			if err == ErrEventIgnored {
 				continue
-			} else if err != nil {
+			}
+			if err != nil {
 				b.Log.Errorf("%#v", err)
 				continue
 			}
-
 			messages <- rmsg
+
 		case *slack.MessageEvent:
-			if b.skipMessageEvent(ev) {
+			if b.skipMessageEventRTM(ev) {
 				b.Log.Debugf("Skipped message: %#v", ev)
 				continue
 			}
-			rmsg, err := b.handleMessageEvent(ev)
+			rmsg, err := b.handleMessageEventRTM(ev)
 			if err != nil {
 				b.Log.Errorf("%#v", err)
 				continue
 			}
 			messages <- rmsg
+
 		case *slack.FileDeletedEvent:
-			rmsg, err := b.handleFileDeletedEvent(ev)
+			rmsg, err := b.handleFileDeleted(ev.FileID)
 			if err != nil {
-				b.Log.Printf("%#v", err)
+				b.Log.Warnf("%#v", err)
 				continue
 			}
 			messages <- rmsg
-		case *slack.OutgoingErrorEvent:
-			b.Log.Debugf("%#v", ev.Error())
+
 		case *slack.ChannelJoinedEvent:
 			// When we join a channel we update the full list of users as
 			// well as the information for the channel that we joined as this
 			// should now tell that we are a member of it.
 			b.channels.registerChannel(ev.Channel)
+		case *slack.MemberJoinedChannelEvent:
+			b.users.populateUser(ev.User)
+		case *slack.UserChangeEvent:
+			b.users.invalidateUser(ev.User.ID)
 		case *slack.ConnectedEvent:
-			b.si = ev.Info
+			b.actingUserID = ev.Info.User.ID
+			b.actingUserName = ev.Info.User.Name
 			b.channels.populateChannels(true)
 			b.users.populateUsers(true)
+
+		case *slack.OutgoingErrorEvent:
+			b.Log.Debugf("%#v", ev.Error())
 		case *slack.InvalidAuthEvent:
 			b.Log.Fatalf("Invalid Token %#v", ev)
 		case *slack.ConnectionErrorEvent:
 			b.Log.Errorf("Connection failed %#v %#v", ev.Error(), ev.ErrorObj)
-		case *slack.MemberJoinedChannelEvent:
-			b.users.populateUser(ev.User)
+
 		case *slack.HelloEvent, *slack.LatencyReport, *slack.ConnectingEvent:
 			continue
-		case *slack.UserChangeEvent:
-			b.users.invalidateUser(ev.User.ID)
 		default:
 			b.Log.Debugf("Unhandled incoming event: %T", ev)
 		}
@@ -126,54 +241,74 @@ func (b *Bslack) handleMatterHook(messages chan *config.Message) {
 	}
 }
 
-// skipMessageEvent skips event that need to be skipped :-)
-func (b *Bslack) skipMessageEvent(ev *slack.MessageEvent) bool {
-	switch ev.SubType {
+func (b *Bslack) skipMessageEventEAPI(ev *slackevents.MessageEvent) bool {
+	return b.skipMessageEvent(ev.Message, ev.PreviousMessage)
+}
+
+func (b *Bslack) skipMessageEventRTM(ev *slack.MessageEvent) bool {
+	msg := &ev.Msg
+	if ev.SubMessage != nil {
+		msg = ev.SubMessage
+	}
+
+	return b.skipMessageEvent(msg, ev.PreviousMessage)
+}
+
+// skipMessageEvent skips event that need to be skipped
+func (b *Bslack) skipMessageEvent(msg *slack.Msg, prevmsg *slack.Msg) bool {
+	if b.skipIgnoredMsgSubtypes(msg) {
+		return true
+	}
+
+	// Check for our callback ID
+	hasOurCallbackID := false
+	if len(msg.Blocks.BlockSet) == 1 {
+		block, ok := msg.Blocks.BlockSet[0].(*slack.SectionBlock)
+		hasOurCallbackID = ok && block.BlockID == "matterbridge_"+b.uuid
+	}
+
+	// skip message changed from attachment changes
+	// this includes link unfurling
+	if msg.SubType == sMessageChanged &&
+		msg.Text == prevmsg.Text &&
+		len(msg.Attachments) != len(prevmsg.Attachments) {
+		return true
+	}
+
+	// Skip any messages that we made ourselves or from 'slackbot' (see #527).
+	usingSockets := b.smc != nil || b.rtm != nil
+	if msg.Username == sSlackBotUser ||
+		(usingSockets && msg.Username == b.actingUserName) ||
+		hasOurCallbackID {
+		return true
+	}
+
+	if len(msg.Files) > 0 {
+		return b.filesCached(msg.Files)
+	}
+
+	return false
+}
+
+func (b *Bslack) skipIgnoredMsgSubtypes(msg *slack.Msg) bool {
+	switch msg.SubType {
 	case sChannelLeave, sChannelJoin:
 		return b.GetBool(noSendJoinConfig)
 	case sPinnedItem, sUnpinnedItem:
 		return true
 	case sChannelTopic, sChannelPurpose:
 		// Skip the event if our bot/user account changed the topic/purpose
-		if ev.User == b.si.User.ID {
+		if msg.User == b.actingUserID {
 			return true
 		}
-	}
-
-	// Check for our callback ID
-	hasOurCallbackID := false
-	if len(ev.Blocks.BlockSet) == 1 {
-		block, ok := ev.Blocks.BlockSet[0].(*slack.SectionBlock)
-		hasOurCallbackID = ok && block.BlockID == "matterbridge_"+b.uuid
-	}
-
-	if ev.SubMessage != nil {
-		// It seems ev.SubMessage.Edited == nil when slack unfurls.
-		// Do not forward these messages. See Github issue #266.
-		if ev.SubMessage.ThreadTimestamp != ev.SubMessage.Timestamp &&
-			ev.SubMessage.Edited == nil {
-			return true
-		}
+	case sMessageReplied:
 		// see hidden subtypes at https://api.slack.com/events/message
 		// these messages are sent when we add a message to a thread #709
-		if ev.SubType == "message_replied" && ev.Hidden {
+		if msg.Hidden {
 			return true
 		}
-		if len(ev.SubMessage.Blocks.BlockSet) == 1 {
-			block, ok := ev.SubMessage.Blocks.BlockSet[0].(*slack.SectionBlock)
-			hasOurCallbackID = ok && block.BlockID == "matterbridge_"+b.uuid
-		}
 	}
 
-	// Skip any messages that we made ourselves or from 'slackbot' (see #527).
-	if ev.Username == sSlackBotUser ||
-		(b.rtm != nil && ev.Username == b.si.User.Name) || hasOurCallbackID {
-		return true
-	}
-
-	if len(ev.Files) > 0 {
-		return b.filesCached(ev.Files)
-	}
 	return false
 }
 
@@ -186,7 +321,25 @@ func (b *Bslack) filesCached(files []slack.File) bool {
 	return true
 }
 
-// handleMessageEvent handles the message events. Together with any called sub-methods,
+func (b *Bslack) handleMessageEventEAPI(ev *slackevents.MessageEvent) (*config.Message, error) {
+	return b.handleMessage(ev.Message, ev.Channel, ev.IsEdited())
+}
+
+func (b *Bslack) handleMessageEventRTM(ev *slack.MessageEvent) (*config.Message, error) {
+	edited := ev.SubMessage != nil && ev.SubMessage.Edited != nil
+
+	msg := &ev.Msg
+	if ev.SubMessage != nil {
+		msg = ev.SubMessage
+	}
+
+	return b.handleMessage(msg, ev.Channel, edited)
+}
+
+var ErrEmptyHandledMessage = errors.New("message handling resulted in an empty message")
+var ErrNoFileInChannel = errors.New("channel ID for file ID not found")
+
+// handleMessage handles the message events. Together with any called sub-methods,
 // this method implements the following event processing pipeline:
 //
 //  1. Check if the message should be ignored.
@@ -202,36 +355,33 @@ func (b *Bslack) filesCached(files []slack.File) bool {
 //  5. Handle any attachments of the received event.
 //  6. Check that the Matterbridge message that we end up with after at the end of the
 //     pipeline is valid before sending it to the Matterbridge router.
-func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, error) {
-	rmsg, err := b.populateReceivedMessage(ev)
+func (b *Bslack) handleMessage(msg *slack.Msg, channel string, edited bool) (*config.Message, error) {
+	rmsg, err := b.populateReceivedMessage(msg, channel, edited)
 	if err != nil {
 		return nil, err
 	}
 
 	// Handle some message types early.
-	if b.handleStatusEvent(ev, rmsg) {
+	if b.handleStatusEvent(msg, rmsg) {
 		return rmsg, nil
 	}
 
-	b.handleAttachments(ev, rmsg)
+	b.handleAttachments(msg, rmsg)
 
 	// Verify that we have the right information and the message
 	// is well-formed before sending it out to the router.
-	if len(ev.Files) == 0 && (rmsg.Text == "" || rmsg.Username == "") {
-		if ev.BotID != "" {
+	if len(msg.Files) == 0 && (rmsg.Text == "" || rmsg.Username == "") {
+		if msg.BotID != "" {
 			// This is probably a webhook we couldn't resolve.
-			return nil, fmt.Errorf("message handling resulted in an empty bot message (probably an incoming webhook we couldn't resolve): %#v", ev)
+			return nil, fmt.Errorf("%w (bot message): %#v", ErrEmptyHandledMessage, msg)
 		}
-		if ev.SubMessage != nil {
-			return nil, fmt.Errorf("message handling resulted in an empty message: %#v with submessage %#v", ev, ev.SubMessage)
-		}
-		return nil, fmt.Errorf("message handling resulted in an empty message: %#v", ev)
+		return nil, fmt.Errorf("%w: %#v", ErrEmptyHandledMessage, msg)
 	}
 	return rmsg, nil
 }
 
-func (b *Bslack) handleFileDeletedEvent(ev *slack.FileDeletedEvent) (*config.Message, error) {
-	if rawChannel, ok := b.cache.Get(cfileDownloadChannel + ev.FileID); ok {
+func (b *Bslack) handleFileDeleted(fileID string) (*config.Message, error) {
+	if rawChannel, ok := b.cache.Get(cfileDownloadChannel + fileID); ok {
 		channel, err := b.channels.getChannelByID(rawChannel.(string))
 		if err != nil {
 			return nil, err
@@ -242,16 +392,16 @@ func (b *Bslack) handleFileDeletedEvent(ev *slack.FileDeletedEvent) (*config.Mes
 			Text:     config.EventFileDelete,
 			Channel:  channel.Name,
 			Account:  b.Account,
-			ID:       ev.FileID,
+			ID:       fileID,
 			Protocol: b.Protocol,
 		}, nil
 	}
 
-	return nil, fmt.Errorf("channel ID for file ID %s not found", ev.FileID)
+	return nil, fmt.Errorf("%w: file ID %s", ErrNoFileInChannel, fileID)
 }
 
-func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) bool {
-	switch ev.SubType {
+func (b *Bslack) handleStatusEvent(msg *slack.Msg, rmsg *config.Message) bool {
+	switch msg.SubType {
 	case sChannelJoined, sMemberJoined:
 		// There's no further processing needed on channel events
 		// so we return 'true'.
@@ -263,16 +413,15 @@ func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message)
 		b.channels.populateChannels(false)
 		rmsg.Event = config.EventTopicChange
 	case sMessageChanged:
-		rmsg.Text = ev.SubMessage.Text
 		// handle deleted thread starting messages
-		if ev.SubMessage.Text == "This message was deleted." {
+		if msg.Text == "This message was deleted." {
 			rmsg.Event = config.EventMsgDelete
 			return true
 		}
 	case sMessageDeleted:
 		rmsg.Text = config.EventMsgDelete
 		rmsg.Event = config.EventMsgDelete
-		rmsg.ID = ev.DeletedTimestamp
+		rmsg.ID = msg.DeletedTimestamp
 		// If a message is being deleted we do not need to process
 		// the event any further so we return 'true'.
 		return true
@@ -289,18 +438,18 @@ func getMessageTitle(attach *slack.Attachment) string {
 	return attach.Title
 }
 
-func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message) {
+func (b *Bslack) handleAttachments(msg *slack.Msg, rmsg *config.Message) {
 	// File comments are set by the system (because there is no username given).
-	if ev.SubType == sFileComment {
+	if msg.SubType == sFileComment {
 		rmsg.Username = sSystemUser
 	}
 
 	// See if we have some text in the attachments.
 	if rmsg.Text == "" {
-		for i, attach := range ev.Attachments {
+		for i, attach := range msg.Attachments {
 			if attach.Text != "" {
 				if attach.Title != "" {
-					rmsg.Text = getMessageTitle(&ev.Attachments[i])
+					rmsg.Text = getMessageTitle(&msg.Attachments[i])
 				}
 				rmsg.Text += attach.Text
 				if attach.Footer != "" {
@@ -313,22 +462,25 @@ func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message)
 	}
 
 	// Save the attachments, so that we can send them to other slack (compatible) bridges.
-	if len(ev.Attachments) > 0 {
-		rmsg.Extra[sSlackAttachment] = append(rmsg.Extra[sSlackAttachment], ev.Attachments)
+	if len(msg.Attachments) > 0 {
+		rmsg.Extra[sSlackAttachment] = append(rmsg.Extra[sSlackAttachment], msg.Attachments)
 	}
 
 	// If we have files attached, download them (in memory) and put a pointer to it in msg.Extra.
-	for i := range ev.Files {
+	for i := range msg.Files {
 		// keep reference in cache on which channel we added this file
-		b.cache.Add(cfileDownloadChannel+ev.Files[i].ID, ev.Channel)
-		if err := b.handleDownloadFile(rmsg, &ev.Files[i], false); err != nil {
+		b.cache.Add(cfileDownloadChannel+msg.Files[i].ID, msg.Channel)
+		if err := b.handleDownloadFile(rmsg, &msg.Files[i], false); err != nil {
 			b.Log.Errorf("Could not download incoming file: %#v", err)
 		}
 	}
 }
 
 func (b *Bslack) handleTypingEvent(ev *slack.UserTypingEvent) (*config.Message, error) {
-	if ev.User == b.si.User.ID {
+	if !b.GetBool("ShowUserTyping") {
+		return nil, ErrEventIgnored
+	}
+	if ev.User == b.actingUserID {
 		return nil, ErrEventIgnored
 	}
 	channelInfo, err := b.channels.getChannelByID(ev.Channel)
@@ -383,7 +535,7 @@ func (b *Bslack) handleGetChannelMembers(rmsg *config.Message) bool {
 
 	cMembers := b.channels.getChannelMembers(b.users)
 
-	extra := make(map[string][]interface{})
+	extra := make(map[string][]any)
 	extra[config.EventGetChannelMembers] = append(extra[config.EventGetChannelMembers], cMembers)
 	msg := config.Message{
 		Extra:   extra,

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -1,6 +1,7 @@
 package bslack
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,73 +14,73 @@ import (
 
 // populateReceivedMessage shapes the initial Matterbridge message that we will forward to the
 // router before we apply message-dependent modifications.
-func (b *Bslack) populateReceivedMessage(ev *slack.MessageEvent) (*config.Message, error) {
+func (b *Bslack) populateReceivedMessage(msg *slack.Msg, channel string, edited bool) (*config.Message, error) {
 	// Use our own func because rtm.GetChannelInfo doesn't work for private channels.
-	channel, err := b.channels.getChannelByID(ev.Channel)
+	schan, err := b.channels.getChannelByID(channel)
 	if err != nil {
 		return nil, err
 	}
 
 	rmsg := &config.Message{
-		Text:     ev.Text,
-		Channel:  channel.Name,
+		Text:     msg.Text,
+		Channel:  schan.Name,
 		Account:  b.Account,
-		ID:       ev.Timestamp,
-		Extra:    make(map[string][]interface{}),
-		ParentID: ev.ThreadTimestamp,
+		ID:       msg.Timestamp,
+		Extra:    make(map[string][]any),
+		ParentID: msg.ThreadTimestamp,
 		Protocol: b.Protocol,
 	}
 	if b.useChannelID {
-		rmsg.Channel = "ID:" + channel.ID
+		rmsg.Channel = "ID:" + schan.ID
 	}
 
-	// Handle 'edit' messages.
-	if ev.SubMessage != nil && !b.GetBool(editDisableConfig) {
-		rmsg.ID = ev.SubMessage.Timestamp
-		if ev.SubMessage.ThreadTimestamp != ev.SubMessage.Timestamp {
-			b.Log.Debugf("SubMessage %#v", ev.SubMessage)
-			rmsg.Text = ev.SubMessage.Text + b.GetString(editSuffixConfig)
+	// Handle 'edit' messages
+	if edited {
+		// For edits, only submessage has thread ts. (and previous message too?)
+		// Ensures edits to threaded messages maintain their prefix hint on the
+		// unthreaded end.
+		rmsg.ParentID = msg.ThreadTimestamp
+
+		if !b.GetBool(editDisableConfig) {
+			rmsg.ID = msg.Timestamp
+			if msg.ThreadTimestamp != msg.Timestamp {
+				b.Log.Debugf("edited msg %#v", msg)
+				rmsg.Text = msg.Text + b.GetString(editSuffixConfig)
+			}
 		}
 	}
 
-	// For edits, only submessage has thread ts.
-	// Ensures edits to threaded messages maintain their prefix hint on the
-	// unthreaded end.
-	if ev.SubMessage != nil {
-		rmsg.ParentID = ev.SubMessage.ThreadTimestamp
-	}
-
-	if err = b.populateMessageWithUserInfo(ev, rmsg); err != nil {
+	if err = b.populateMessageWithUserInfo(msg, rmsg); err != nil {
 		return nil, err
 	}
 	return rmsg, err
 }
 
-func (b *Bslack) populateMessageWithUserInfo(ev *slack.MessageEvent, rmsg *config.Message) error {
-	if ev.SubType == sMessageDeleted || ev.SubType == sFileComment {
+var ErrNoUserInfo = errors.New("could not find information for user")
+
+func (b *Bslack) populateMessageWithUserInfo(msg *slack.Msg, rmsg *config.Message) error {
+	if msg.SubType == sMessageDeleted || msg.SubType == sFileComment {
 		return nil
 	}
 
-	// First, deal with bot-originating messages but only do so when not using webhooks: we
-	// would not be able to distinguish which bot would be sending them.
-	if err := b.populateMessageWithBotInfo(ev, rmsg); err != nil {
+	// First, deal with bot-originating messages but only do so when not using webhooks:
+	// we would not be able to distinguish which bot would be sending them.
+	if err := b.populateMessageWithBotInfo(msg.BotID, msg.Username, rmsg); err != nil {
 		return err
 	}
 
 	// Second, deal with "real" users if we have the necessary information.
 	var userID string
 	switch {
-	case ev.User != "":
-		userID = ev.User
-	case ev.SubMessage != nil && ev.SubMessage.User != "":
-		userID = ev.SubMessage.User
+	case msg.User != "":
+		userID = msg.User
 	default:
 		return nil
 	}
 
 	user := b.users.getUser(userID)
 	if user == nil {
-		return fmt.Errorf("could not find information for user with id %s", ev.User)
+		return fmt.Errorf("%w: id %s", ErrNoUserInfo, msg.User)
 	}
 
 	rmsg.UserID = user.ID
@@ -93,16 +94,16 @@ func (b *Bslack) populateMessageWithUserInfo(ev *slack.MessageEvent, rmsg *confi
 	return nil
 }
 
-func (b *Bslack) populateMessageWithBotInfo(ev *slack.MessageEvent, rmsg *config.Message) error {
-	if ev.BotID == "" || b.GetString(outgoingWebhookConfig) != "" {
+func (b *Bslack) populateMessageWithBotInfo(botID string, username string, rmsg *config.Message) error {
+	if botID == "" || b.GetString(outgoingWebhookConfig) != "" {
 		return nil
 	}
 
 	var err error
 	var bot *slack.Bot
 	for {
-		bot, err = b.rtm.GetBotInfo(slack.GetBotInfoParameters{
-			Bot: ev.BotID,
+		bot, err = b.sc.GetBotInfo(slack.GetBotInfoParameters{
+			Bot: botID,
 		})
 		if err == nil {
 			break
@@ -117,8 +118,8 @@ func (b *Bslack) populateMessageWithBotInfo(ev *slack.MessageEvent, rmsg *config
 
 	if bot.Name != "" {
 		rmsg.Username = bot.Name
-		if ev.Username != "" {
-			rmsg.Username = ev.Username
+		if username != "" {
+			rmsg.Username = username
 		}
 		rmsg.UserID = bot.ID
 	}
@@ -253,5 +254,21 @@ func handleRateLimit(log *logrus.Entry, err error) error {
 	}
 	log.Infof("Rate-limited by Slack. Sleeping for %v", rateLimit.RetryAfter)
 	time.Sleep(rateLimit.RetryAfter)
+	return nil
+}
+
+// smlog slack socketmode logger shim for logrus logger
+// all messages will be logged with level debug
+//
+// CAVEAT: due to logrus' limitation, the logged source location is inaccurate
+// and it's impossible to inject custom caller location information for logging
+type smlog struct {
+	*logrus.Entry
+}
+
+// Output output given message to the logger
+func (l *smlog) Output(skip int, msg string) error {
+	l.Debug(msg)
+
 	return nil
 }

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -2,6 +2,7 @@ package bslack
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -15,16 +16,25 @@ import (
 	"github.com/matterbridge-org/matterbridge/matterhook"
 	"github.com/rs/xid"
 	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
 )
 
 type Bslack struct {
 	sync.RWMutex
 	*bridge.Config
 
-	mh  *matterhook.Client
-	sc  *slack.Client
+	mh *matterhook.Client
+	sc *slack.Client
+
+	// legacy RTM connection
 	rtm *slack.RTM
-	si  *slack.Info
+
+	// new socket based Events API connection
+	smc     *socketmode.Client
+	smcStop context.CancelFunc
+
+	actingUserID   string
+	actingUserName string
 
 	cache        *lru.Cache
 	uuid         string
@@ -43,6 +53,7 @@ const (
 	sMemberJoined        = "member_joined_channel"
 	sMessageChanged      = "message_changed"
 	sMessageDeleted      = "message_deleted"
+	sMessageReplied      = "message_replied"
 	sSlackAttachment     = "slack_attachment"
 	sPinnedItem          = "pinned_item"
 	sUnpinnedItem        = "unpinned_item"
@@ -57,6 +68,7 @@ const (
 	cfileDownloadChannel = "file_download_channel"
 
 	tokenConfig           = "Token"
+	appTokenConfig        = "AppToken"
 	incomingWebhookConfig = "WebhookBindAddress"
 	outgoingWebhookConfig = "WebhookURL"
 	skipTLSConfig         = "SkipTLSVerify"
@@ -69,13 +81,23 @@ const (
 )
 
 func New(cfg *bridge.Config) bridge.Bridger {
-	// Print a deprecation warning for legacy non-bot tokens (#527).
 	token := cfg.GetString(tokenConfig)
+	appToken := cfg.GetString(appTokenConfig)
+	if appToken != "" && !strings.HasPrefix(appToken, "xapp-") {
+		cfg.Log.Error("App token missing `xapp-` prefix")
+	}
+	// Print a deprecation warning for legacy non-bot tokens (#527).
 	if token != "" && !strings.HasPrefix(token, "xoxb") {
 		cfg.Log.Warn("Non-bot token detected. It is STRONGLY recommended to use a proper bot-token instead.")
 		cfg.Log.Warn("Legacy tokens may be deprecated by Slack at short notice. See the Matterbridge GitHub wiki for a migration guide.")
 		cfg.Log.Warn("See https://github.com/42wim/matterbridge/wiki/Slack-bot-setup")
 		return NewLegacy(cfg)
+	}
+	// print warning for RTM + classic slack apps setup
+	if strings.HasPrefix(token, "xoxb-") && appToken == "" {
+		cfg.Log.Warn("Bot token with classic Slack apps setup detected.")
+		cfg.Log.Warn("It is recommended to use modern Slack apps with socket mode Events API instead.")
+		cfg.Log.Warn("See https://github.com/matterbridge-org/matterbridge/blob/master/docs/protocols/slack/account.md")
 	}
 	return newBridge(cfg)
 }
@@ -105,18 +127,31 @@ func (b *Bslack) Connect() error {
 		return errors.New("no connection method found: WebhookBindAddress, WebhookURL or Token need to be configured")
 	}
 
-	// If we have a token we use the Slack websocket-based RTM for both sending and receiving.
-	if token := b.GetString(tokenConfig); token != "" {
+	appToken := b.GetString(appTokenConfig)
+	token := b.GetString(tokenConfig)
+	debug := b.GetBool("Debug")
+
+	// If we have a token we use the Slack websocket-based RTM or Events API for both sending and receiving.
+	if token != "" {
 		b.Log.Info("Connecting using token")
 
-		b.sc = slack.New(token, slack.OptionDebug(b.GetBool("Debug")))
+		b.sc = slack.New(token, slack.OptionDebug(debug), slack.OptionAppLevelToken(appToken))
 
 		b.channels = newChannelManager(b.Log, b.sc)
 		b.users = newUserManager(b.Log, b.sc)
 
-		b.rtm = b.sc.NewRTM()
-		go b.rtm.ManageConnection()
+		// if app token is set then prefer using socketmode events rather than legacy RTM
+		if appToken != "" {
+			ctx, stop := context.WithCancel(context.Background())
+			b.smc = socketmode.New(b.sc, socketmode.OptionDebug(debug), socketmode.OptionLog(&smlog{b.Log}))
+			b.smcStop = stop
+			go b.startSocketEAPIConnection(ctx)
+		} else {
+			b.rtm = b.sc.NewRTM()
+			go b.rtm.ManageConnection()
+		}
 		go b.handleSlack()
+
 		return nil
 	}
 
@@ -142,7 +177,14 @@ func (b *Bslack) Connect() error {
 }
 
 func (b *Bslack) Disconnect() error {
-	return b.rtm.Disconnect()
+	if b.smc != nil {
+		b.smcStop()
+		return nil
+	}
+	if b.rtm != nil {
+		return b.rtm.Disconnect()
+	}
+	return nil
 }
 
 // JoinChannel only acts as a verification method that checks whether Matterbridge's
@@ -208,7 +250,7 @@ func (b *Bslack) Send(msg config.Message) (string, error) {
 	if b.GetString(outgoingWebhookConfig) != "" && b.GetString(tokenConfig) == "" {
 		return "", b.sendWebhook(msg)
 	}
-	return b.sendRTM(msg)
+	return b.sendAPI(msg)
 }
 
 // sendWebhook uses the configured WebhookURL to send the message
@@ -225,7 +267,6 @@ func (b *Bslack) sendWebhook(msg config.Message) error {
 	if msg.Extra != nil {
 		// This sends a message only if we received a config.EVENT_FILE_FAILURE_SIZE.
 		for _, rmsg := range helper.HandleExtra(&msg, b.General) {
-			rmsg := rmsg // scopelint
 			iconURL := config.GetIconURL(&rmsg, b.GetString(iconURLConfig))
 			matterMessage := matterhook.OMessage{
 				IconURL:  iconURL,
@@ -275,7 +316,7 @@ func (b *Bslack) sendWebhook(msg config.Message) error {
 	return nil
 }
 
-func (b *Bslack) sendRTM(msg config.Message) (string, error) {
+func (b *Bslack) sendAPI(msg config.Message) (string, error) {
 	// Handle channelmember messages.
 	if handled := b.handleGetChannelMembers(&msg); handled {
 		return "", nil
@@ -285,8 +326,10 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not send message: %v", err)
 	}
+
+	// this one is RTM specific
 	if msg.Event == config.EventUserTyping {
-		if b.GetBool("ShowUserTyping") {
+		if b.GetBool("ShowUserTyping") && b.rtm != nil {
 			b.rtm.SendMessage(b.rtm.NewTypingMessage(channelInfo.ID))
 		}
 		return "", nil
@@ -339,15 +382,27 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 	return b.postMessage(&msg, channelInfo)
 }
 
+func (b *Bslack) startSocketEAPIConnection(ctx context.Context) {
+	for {
+		err := b.smc.RunContext(ctx)
+		b.Log.Warnf("Slack socket mode client stopped with: %v", err)
+
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
 func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Channel) error {
 	var updateFunc func(channelID string, value string) (*slack.Channel, error)
 
 	incomingChangeType, text := b.extractTopicOrPurpose(msg.Text)
 	switch incomingChangeType {
 	case "topic":
-		updateFunc = b.rtm.SetTopicOfConversation
+		updateFunc = b.sc.SetTopicOfConversation
 	case "purpose":
-		updateFunc = b.rtm.SetPurposeOfConversation
+		updateFunc = b.sc.SetPurposeOfConversation
 	default:
 		b.Log.Errorf("Unhandled type received from extractTopicOrPurpose: %s", incomingChangeType)
 		return nil
@@ -393,7 +448,7 @@ func (b *Bslack) deleteMessage(msg *config.Message, channelInfo *slack.Channel) 
 	}
 
 	for {
-		_, _, err := b.rtm.DeleteMessage(channelInfo.ID, msg.ID)
+		_, _, err := b.sc.DeleteMessage(channelInfo.ID, msg.ID)
 		if err == nil {
 			return true, nil
 		}
@@ -411,7 +466,7 @@ func (b *Bslack) editMessage(msg *config.Message, channelInfo *slack.Channel) (b
 	}
 	messageOptions := b.prepareMessageOptions(msg)
 	for {
-		_, _, _, err := b.rtm.UpdateMessage(channelInfo.ID, msg.ID, messageOptions...)
+		_, _, _, err := b.sc.UpdateMessage(channelInfo.ID, msg.ID, messageOptions...)
 		if err == nil {
 			return true, nil
 		}
@@ -430,7 +485,7 @@ func (b *Bslack) postMessage(msg *config.Message, channelInfo *slack.Channel) (s
 	}
 	messageOptions := b.prepareMessageOptions(msg)
 	for {
-		_, id, err := b.rtm.PostMessage(channelInfo.ID, messageOptions...)
+		_, id, err := b.sc.PostMessage(channelInfo.ID, messageOptions...)
 		if err == nil {
 			return id, nil
 		}
@@ -540,10 +595,13 @@ func (b *Bslack) prepareMessageOptions(msg *config.Message) []slack.MsgOption {
 	return opts
 }
 
-func (b *Bslack) createAttach(extra map[string][]interface{}) []slack.Attachment {
+func (b *Bslack) createAttach(extra map[string][]any) []slack.Attachment {
 	var attachements []slack.Attachment
 	for _, v := range extra["attachments"] {
-		entry := v.(map[string]interface{})
+		entry, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
 		s := slack.Attachment{
 			Fallback:   extractStringField(entry, "fallback"),
 			Color:      extractStringField(entry, "color"),
@@ -564,7 +622,7 @@ func (b *Bslack) createAttach(extra map[string][]interface{}) []slack.Attachment
 	return attachements
 }
 
-func extractStringField(data map[string]interface{}, field string) string {
+func extractStringField(data map[string]any, field string) string {
 	if rawValue, found := data[field]; found {
 		if value, ok := rawValue.(string); ok {
 			return value

--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,10 @@
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
   - whatsapp
     - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings
+- slack
+  - added support for using socket mode Events API to receive messages for bridging instead of RTM.
+    this allows new slack bridge to be set up using modern slack apps and its tokens; see the slack docs for setup instructions ([#149](https://github.com/matterbridge-org/matterbridge/pull/149)).  
+    note that the existing slack bridge setup using bot token with _classic_ slack apps should continue to work as before, until slack decides to turn off RTM system.
 
 ## Bugfixes
 

--- a/docs/protocols/slack/README.md
+++ b/docs/protocols/slack/README.md
@@ -12,10 +12,13 @@
 [slack]
 [slack.myslack]
 RemoteNickFormat="{BRIDGE} - @{NICK}"
-Token="#####"
+# this requires *two* different tokens
+Token="xoxb-*****"
+AppToken="xapp-*****"
 # this will maps threads from other bridges on slack threads
 PreserveThreading=true
 ```
+
 
 ## FAQ
 
@@ -23,25 +26,46 @@ PreserveThreading=true
 
 See [account.md](account.md).
 
-## Auth Comparison
-
-This is a simple comparison of the Slack connection methods, to help you understand and differentiate between each:
-
-| 👇 Feature \ Token Type 👉 | Bot user | Legacy<br/>(personal account) | Legacy<br/>(dedicated account) |
-|---|:---:|:---:|:---:|
-| Bridge Type | `slack` | `slack-legacy` | `slack-legacy` |
-| Token prefix | `xoxb-` | `xoxp-` | `xoxp-` |
-| Supported | ✅ |   | ✅ |
-| 1. Auto-join channels |   | ✅ | ✅ |
-| 3. Uses separate integration slot | :x: |   |   |
-| 4. User's outgoing messages relayed | ✅ |   | ✅ |
-| 5. File uploads show as from... | bot | you | dedicated user |# Slack
-
-## Messages come from Slack API tester
+### Messages come from Slack API tester
 Did you set `RemoteNickFormat`?    
 Try adding `RemoteNickFormat="<{NICK}>"`
 
-## Messages from other bots aren't getting relayed
+### Messages from other bots aren't getting relayed
 
 If you're using `WebhookURL` in your Slack configuration, this is normal.
 If you only have `Token` configuration, this could be a bug. Please open an issue.
+
+### `"not_allowed_token_type"` error in the logs
+
+If you get the message:
+
+```
+ERROR slack: Connection failed "not_allowed_token_type" &errors.errorString{s:"not_allowed_token_type"}
+```
+
+For more information look at:
+
+- https://github.com/slackapi/node-slack-sdk/issues/921#issuecomment-570662540
+- https://github.com/nlopes/slack/issues/654
+- our issue https://github.com/42wim/matterbridge/issues/964
+
+## Notes regarding bot based setup tokens
+
+The bot based setup can currently operate in 2 modes:
+
+- **socket mode Events API mode** (recommended, preferred)  
+  this mode works with modern Slack apps and is recommended for setting up Slack bridges.
+  However this mode requires **two** tokens to operate:
+  - a _Bot User OAuth Token_ bot token having prefix `xoxb-`, configured with `Token=` option
+  - an App token having prefix `xapp-`, configured with `AppToken=` option
+
+- **legacy RTM mode**  
+  previously the primary mode of operation for the bridge.
+  This mode only works with bot token belonging to a *classic* Slack apps;
+  and as of 2024-06-04 it's no longer possible to create any new classic Slack apps.
+  This mode only requires a single bot token `Token=` to be configured.
+
+  If you already have an existing bridge setups with classic Slack apps then it should
+  continue to work as before without changing the existing Slack app settings or matterbridge config
+  (leave the `AppToken=` unset or set to empty value).
+  Should you want to set up a new bridge, then the socket mode Events API mode is the recommended (and the only) way forward.

--- a/docs/protocols/slack/README.md
+++ b/docs/protocols/slack/README.md
@@ -1,7 +1,7 @@
 # Slack
 
 - Status: ???
-- Maintainers: ???
+- Maintainers: @asdfzdfj
 - Features: ???
 
 ## Configuration

--- a/docs/protocols/slack/account.md
+++ b/docs/protocols/slack/account.md
@@ -1,62 +1,92 @@
 # A Matterbridge integration for your Slack Workspace
 
-### Contents
+> [!IMPORTANT]
+> the bot based setup is the only supported method of integration,
+> any other methods that was previously listed here is deprecated and no longer supported,
+> may just straight up not working, and will be removed in the future.
 
-[Bot-based Setup](#bot-based-setup)<br/>
-<strike>[Legacy Setup](#legacy-setup)</strike><br/>
-[Issues](#issues)
+## Bot-based Setup
 
----
-
-# Bot-based Setup
 Slack's model for bot users and other third-party integrations revolves around Slack Apps. They have been around for a while and are the only and default way of integrating services like Matterbridge going forward.
 
 Slack Docs: [Bot user tokens](https://api.slack.com/docs/token-types#bot)
 
-## Create the **classic** Slack App
-> **It's important that you create a "Slack App (Classic)". Don't use the "Create New App" button, and don't opt in to the "granular permissions" feature.**
+You will be creating **two** tokens, both are required to configure a Slack bridge:
+
+- a _Bot User OAuth Token_ Bot token, with prefix `xoxb-`
+- an App Token, with prefix `xapp-`
+
+### Create the Slack App
 
 1. Navigate to Slack's ["Your Apps" page](https://api.slack.com/apps) and log into an account that has administrative permissions over the Slack Workspace (server) that you want to sync with Matterbridge.
 
-   <img alt="Slack's 'Your Apps' page" width=780 src="https://user-images.githubusercontent.com/22248748/119397026-9f1b7500-bca3-11eb-98e6-b3ea925333de.png" />
+   <img alt="Create New App" width="1059" height="315" alt="image" src="https://github.com/user-attachments/assets/37f6a034-2734-4f40-a678-4204782e7c56" />
 
-2. Use [_**THIS LINK**_](https://api.slack.com/apps?new_classic_app=1) to create a "Slack App (Classic)". Choose any name for your app and select the desired workspace, and then submit. :warning: _**USE THE LINK AND DON'T CLICK THE "Create New App" BUTTON**_.
+2. Click the "Create New App" button, select "From scratch", Choose any name for your app and select the desired workspace, and then submit.
 
-   <img alt="Create a 'Slack App (Classic)'" width=780 src="https://user-images.githubusercontent.com/22248748/119397031-9f1b7500-bca3-11eb-9eaa-cc2418adb9db.png" />
+   <img alt="Create New App dialogs" width="1116" height="551" alt="image" src="https://github.com/user-attachments/assets/a94ee7ee-1cb4-4fb3-99bb-46a628a2cea8" />
 
-3. Navigate to the "App Home" page via the menu on the left. Click "Add Legacy Bot User", fill in the bot's details, and submit.
+### Enable socket mode and Creating App Token
 
-   <img alt="Add Legacy Bot User" width=780 src="https://user-images.githubusercontent.com/22248748/119397034-9fb40b80-bca3-11eb-8187-df62925c24f1.png" />
+The bridge connects to Slack using socket mode Events API, but they have to be enabled first.
 
-## Grant scopes and install the Slack App
+Navigate to the "Socket Mode" page via the menu on the left. Toggle on "Connect using Socket Mode" and and follow the dialog to generate a new App Token with `connections:write`, then submit.
 
-You'll need to give your new Slack App (Classic), and thus the bot, the right permissions on your Slack Workspace.
+<img alt="Toggle for enable Socket mode" width="706" height="252" alt="image" src="https://github.com/user-attachments/assets/d0408fe6-aef9-4144-a177-b735e292c836" />
 
-1. Click "OAuth & Permissions" in the menu on the left, and scroll down to the "Scopes" section. Don't click the prominent "Update Scopes" button. Instead, click "Add an OAuth Scope".
+Note down the App Token (with prefix `xapp-`) which you will use in Matterbridge configuration.
 
-   <img alt="Add an OAuth Scope" width=780 src="https://user-images.githubusercontent.com/22248748/119397023-9dea4800-bca3-11eb-9957-c780e96f0960.png" />
+### Grant bot token scopes and install the Slack App
 
-2. Add the following permission scopes to your app:
-   * Modify your public channels (`channels:write`)
-   * Send messages as \<App name\> (`chat:write:bot`)
-   * Send messages as user (`chat:write:user`)
-   * Access user’s profile and workspace profile fields (`users.profile:read`)
+You'll need to give your new Slack App, and thus the bot, the right permissions on your Slack Workspace.
 
-   <img alt="App with scopes" width=780 src="https://user-images.githubusercontent.com/22248748/119397039-a17dcf00-bca3-11eb-9bf4-25cd24f96aaf.png" />
+2. Click "OAuth & Permissions" in the menu on the left, and scroll down to the "Scopes" section. click "Add an OAuth Scope" under "Bot Token Scopes" section.
 
-3. Scroll to the top of the same "OAuth & Permissions" page and click on the "Install to Workspace" (or "Reinstall to Workspace") button:
+   <img alt="Add OAuth Scopes for Bot Token" width="587" height="372" alt="image" src="https://github.com/user-attachments/assets/b4aa1bd4-df56-4e35-8654-4b8d518d5324" />
 
-   <img alt="Install to Workspace" width=780 src="https://user-images.githubusercontent.com/22248748/119397036-a04ca200-bca3-11eb-99a8-545d74effde0.png" />
+3. Add the following scopes:
+   - `calls:read`
+   - `channels:history`
+   - `channels:read`
+   - `chat:write.customize`
+   - `chat:write`
+   - `dnd:read`
+   - `files:read`
+   - `files:write`
+   - `groups:history`
+   - `groups:read`
+   - `im:history`
+   - `im:write`
+   - `mpim:history`
+   - `mpim:read`
+   - `mpim:write`
+   - `pins:write`
+   - `reactions:read`
+   - `reactions:write`
+   - `remote_files:read`
+   - `remote_files:share`
+   - `remote_files:write`
+   - `team:read`
+   - `users.profile:read`
+   - `users:read.email`
+   - `users:read`
+   - `users:write`
 
-Confirm that the authorizations you just added are OK:
+   <img alt="Bot Token scopes" width="589" height="606" alt="image" src="https://github.com/user-attachments/assets/c51062d1-ea01-4770-bdf1-d78c4ae3ee3e" />
 
-   <img alt="Confirm install" width=780 src="https://user-images.githubusercontent.com/22248748/119397035-a04ca200-bca3-11eb-9cf2-edac292fa06c.png" />
+4. Scroll to the top of the same "OAuth & Permissions" page and click on the "Install to Workspace" (or "Reinstall to Workspace") button:
 
-4. Once the App has been installed, the top of the `OAuth & Permissions` page will show two tokens: a "User OAuth Token" starting with `xoxp-...` and a "Bot User OAuth Token" starting with `xoxb-...`. You will need to use the second in your Matterbridge configuration:
+   <img alt="(re)Install the App" width="971" height="745" alt="image" src="https://github.com/user-attachments/assets/6fd5ea2f-f608-4e4f-a02b-a2fbd0d9fb98" />
 
-   <img alt="Bot User OAuth Token" width=780 src="https://user-images.githubusercontent.com/22248748/119397029-9f1b7500-bca3-11eb-9faa-0978a0b280e8.png" />
+   Confirm that the authorizations you just added are OK:
 
-## Invite the bot to channels synced with Matterbridge
+   <img alt="App install authorization" width="879" height="733" alt="image" src="https://github.com/user-attachments/assets/4ee40be3-2c32-401c-93cd-d7aeb1759f09" />
+
+5. Once the App has been installed, the top of the "OAuth & Permissions" page will show a "Bot User OAuth Token" Bot token with prefix `xoxb-`. You will use this in your Matterbridge configuration together with the App Token above:
+
+   <img alt="Bot User OAuth Token" width="692" height="343" alt="image" src="https://github.com/user-attachments/assets/5089acb5-6b1b-4a4e-b3ae-87d8bffecf2e" />
+
+### Invite the bot to channels synced with Matterbridge
 
 The only thing that remains now is to set up the newly created bot on the Slack Workspace itself.
 
@@ -64,42 +94,9 @@ The only thing that remains now is to set up the newly created bot on the Slack 
 
    <img width="527" alt="Invite the bot user to a channel" src="https://user-images.githubusercontent.com/22248748/119407127-c9742f00-bcb1-11eb-870d-7e38335f58df.png">
 
-2. Repeat the invite process for each channel that Matterbridge needs to sync. :warning: Also, don't forget to do this in the future when you want to sync more channels.
+2. Repeat the invite process for each channel that Matterbridge needs to sync.
+   :warning: Also, don't forget to do this in the future when you want to sync more channels.
 
 Now you are all set to go. Just configure and start your Matterbridge instance and see the messages flowing.
 
    <img width="487" alt="Hello from Zulip!" src="https://user-images.githubusercontent.com/22248748/119406733-320edc00-bcb1-11eb-9e20-28ecd0b98d5d.png">
-
-
-# Legacy setup
-
-Update: 2020-04-03 - this setup is not working anymore. (See https://github.com/42wim/matterbridge/issues/964#issuecomment-607629250)
-
-🛑 This setup is not recommended and will disappear in future versions of Matterbridge. Please use it only if you are absolutely sure that you can not use the normal setup. Legacy tokens are, as their name indicates, a legacy feature and Slack can in the future **deprecate them at short notice** as they have a weak security model and **give access to a wide-range of privileged actions**. Always store your token securely!
-
-Slack Docs: [Legacy tokens](https://api.slack.com/docs/token-types#legacy)
-
-***
-
-In order to use this setup your channel configuration should use the `slack-legacy` setup instead of `slack`:
-```toml
-[slack-legacy]
-[slack-legacy.myslack]
-Token="xoxp-123456789-mytoken"
-```
-
-Steps to follow:
-1. First create a dedicated user (a new account specifically for the bot) in Slack.
-
-2. Next log in as this user and go to [the legacy tokens page](https://api.slack.com/custom-integrations/legacy-tokens) and click "Create token" for your team and your new user.
-   ![Create token screen](https://i.snag.gy/vpsSM4.jpg)
-   The token will look something like ```xoxp-123456789-LowerAndUPpercase```.
-
-3. Use the obtained token in your configuration file for the channel setup as in the example above.
-
-# Issues
-
-If you get the message: `ERROR slack: Connection failed "not_allowed_token_type" &errors.errorString{s:"not_allowed_token_type"}`
-
-For more information look at https://github.com/slackapi/node-slack-sdk/issues/921#issuecomment-570662540 and https://github.com/nlopes/slack/issues/654 and our issue https://github.com/42wim/matterbridge/issues/964
-

--- a/docs/protocols/slack/settings.md
+++ b/docs/protocols/slack/settings.md
@@ -56,13 +56,28 @@ Only works syncing topic changes from slack bridge for now
 
 ## Token
 
-Token to connect with the Slack API
+Token to connect with the Slack API to perform actions via its Web API.
 
-- Setting: **REQUIRED** (when not using webhooks)
+- Setting: **REQUIRED** for bot-based setup, for both classic and modern Slack app.
 - Format: *string*
 - Example:
   ```toml
-  Token="yourslacktoken"
+  Token="xoxb-*****"
+  ```
+
+## AppToken
+
+App Token to connect with the Slack API using socket mode Events API to receive messages to bridge.
+
+For a bot token belonging to a _classic_ Slack apps, this **MUST** be unset or set to empty value.
+For modern socket mode Events API based setup, this **MUST** be set to the app token
+with the `connections:write` scope associated to it.
+
+- Setting: **REQUIRED** (see above remarks)
+- Format: *string*
+- Example:
+  ```toml
+  AppToken="xapp-*****"
   ```
 
 ### IconURL

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -512,7 +512,6 @@ StripNick=false
 ShowTopicChange=false
 
 ###################################################################
-<<<<<<< HEAD
 #
 # Keybase
 # You should have a separate bridge account on Keybase
@@ -659,12 +658,18 @@ PreserveThreading=false
 #In this example we use [slack.hobby]
 #REQUIRED
 [slack.hobby]
-#Token to connect with the Slack API
-#You'll have to use a test/api-token using a dedicated user and not a bot token.
-#See https://github.com/42wim/matterbridge/issues/75 for more info.
-#Use https://api.slack.com/custom-integrations/legacy-tokens
-#REQUIRED (when not using webhooks)
-Token="yourslacktoken"
+# Token to connect with the Slack API
+# This should be a bot token associated with the Slack app for the bridge
+# See the matterbridge slack docs for how to obtain this token:
+# https://github.com/matterbridge-org/matterbridge/blob/master/docs/protocols/slack/account.md
+# REQUIRED for both socket mode (recommended in 2026) and classic app setup
+Token="xoxb-*****"
+
+# Slack App Token
+# Required for socket mode Events API (i.e. modern Slack apps), and will automatically use it when set
+# the token MUST have the `connections:write` scope
+# REQUIRED except when using bot token belonging to a classic Slack apps, then set it to empty value
+AppToken="xapp-*****"
 
 #Extra slack specific debug info, warning this generates a lot of output.
 #OPTIONAL (default false)


### PR DESCRIPTION
the current slack bridge with bot token setup relies on legacy RTM API/system to receive messages for bridging, which is only available to classic slack apps, but as of now it's not possible to create new classic slack apps anymore (not even with the link in the current slack documents)

this patch adds support for using socket mode Events API to receive messages for bridging instead of RTM, however this will require an additional App Token with `connections:write` scope to be supplied

from initial testing it seems to be working, but I have put this up as a WIP for now as it could use some polish and additional testing, especially with existing RTM based setup and confirm that it didn't break things over there

