### PR TITLE
IRC attachment fixes

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -50,16 +50,36 @@ func (b *Birc) handleFiles(msg *config.Message) bool {
 	if len(msg.Extra["file"]) == 0 {
 		return false
 	}
+
+	// We have some attachments, which may or may not have a caption
+	// First, let's print the message body, if any
+	if msg.Text != "" {
+		b.Local <- config.Message{Text: msg.Text, Username: msg.Username, Channel: msg.Channel, Event: msg.Event}
+	}
+
 	for _, f := range msg.Extra["file"] {
 		fi := f.(config.FileInfo)
-		if fi.Comment != "" {
-			msg.Text += fi.Comment + " : "
+
+		if fi.URL == "" {
+			// IRC does not support raw bytes upload.
+			//
+			// Here we just produce an error to be announced and logged, hoping the
+			// matterbridge operator will finally enable the media server.
+			msg.Text = fmt.Sprintf("Could not share file %s (no mediaserver configured)", fi.Name)
+			b.Local <- config.Message{Text: msg.Text, Username: "<matterbridge>", Channel: msg.Channel, Event: msg.Event}
+
+			b.Log.Error(msg.Text)
+
+			continue
 		}
-		if fi.URL != "" {
+
+		// File has a public URL, either because it's provided by the remote bridge,
+		// or because the media server is enabled. Share it alongside the
+		// attachment caption, if any.
+		if fi.Comment == "" {
 			msg.Text = fi.URL
-			if fi.Comment != "" {
-				msg.Text = fi.Comment + " : " + fi.URL
-			}
+		} else {
+			msg.Text = fi.Comment + " : " + fi.URL
 		}
 		b.Local <- config.Message{Text: msg.Text, Username: msg.Username, Channel: msg.Channel, Event: msg.Event}
 	}

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,14 @@
   - attachments of mixed types in the same message will be uploaded as documents
 - slack
   - file uploading now use the new upload steps described in the slack docs via `UploadFileV2`, replacing the deprecated and now disabled `file.upload` based method (via `UploadFile`) ([#129](https://github.com/matterbridge-org/matterbridge/pull/129))
+- discord
+  - attached files are always downloaded, so when the media server is enabled, URLs can stay valid
+    longer than Discord URLs ([#37](https://github.com/matterbridge-org/matterbridge/issues/37))
+- irc
+  - when there are attachments in the message, the body is now sent instead of being discarded silently ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
+  - when an attachment has no public URL, an error message is printed/logged encouraging the
+    matterbridge operator to enable the mediaserver, instead of producing an incoherent message
+    ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
 
 ## Upstream
 

--- a/docs/protocols/irc/README.md
+++ b/docs/protocols/irc/README.md
@@ -40,3 +40,17 @@ Nick="yournick"
 Server="irc.oftc.net:6697"
 RunCommands=["PRIVMSG nickserv :IDENTIFY yourpass yournick"]
 ```
+
+# FAQ
+
+## Why can't matterbridge share files on IRC without a mediaserver?
+
+If you see in the chat the error « Could not share file FILE (no mediaserver configured) »,
+it means matterbridge tried to share a file which has no public URL when no media server
+is configured. Files from networks which provide us with a public URL are unaffected
+and can be shared to IRC freely.
+
+Some files such as Matrix file attachments are shared privately and while matterbridge
+can access the file content (raw bytes), there's no link to the file. In order to produce
+a link that can be shared on IRC, you need to enable [a mediaserver](../../advanced/mediaserver.md),
+which requires a public-facing web server.


### PR DESCRIPTION
Cherry-picks from my testing branch, see discussion in https://github.com/matterbridge-org/matterbridge/issues/116

- one commit makes sure we don't discard the message body accompanying an attachment
- one commit makes sure if there's no URL, we don't do anything funky but just display a user-visible error, and adds an FAQ entry in the IRC docs about what the error means