### PR TITLE
Matrix attachment improvements

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -787,17 +787,30 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 		return fmt.Errorf("mtype isn't a %T", mtype)
 	}
 
-	// check if we have an image uploaded without extension
-	if !strings.Contains(name, ".") {
-		if msgtype == "m.image" {
-			mext, _ := mime.ExtensionsByType(mtype)
-			if len(mext) > 0 {
-				name += mext[0]
-			}
-		} else {
-			// just a default .png extension if we don't have mime info
-			name += ".png"
+	b.Log.Debugf("Processing attachment %s with mimetype %s", name, mtype)
+
+	// If the mime library can't guess an appropriate extension for that
+	// content-type, we're not going to deal with that content because other
+	// bridges will have problems too.
+	mext, err := mime.ExtensionsByType(mtype)
+	if err != nil {
+		return err
+	}
+
+	// Make sure file has an extension matching the mimetype.
+	foundExt := false
+
+	for _, ext := range mext {
+		if strings.HasSuffix(name, ext) {
+			foundExt = true
+			break
 		}
+	}
+
+	if !foundExt {
+		// No extension was found, set the first matching extension
+		// according to the mime library.
+		name += mext[0]
 	}
 
 	// Now that we have performed sanity checks and edited the filename,
@@ -806,7 +819,7 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 	rmsg.Text = ""
 
 	// TODO: add attachment ID?
-	err := b.AddAttachmentFromProtectedURL(rmsg, name, "", caption, url)
+	err = b.AddAttachmentFromProtectedURL(rmsg, name, "", caption, url)
 	if err != nil {
 		return err
 	}

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -776,6 +776,8 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 	if name, ok = content.Raw["body"].(string); !ok {
 		return fmt.Errorf("name isn't a %T", name)
 	}
+	// The attachment caption is the raw, unadultered message body
+	caption := name
 
 	if msgtype, ok = content.Raw["msgtype"].(string); !ok {
 		return fmt.Errorf("msgtype isn't a %T", msgtype)
@@ -798,8 +800,13 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 		}
 	}
 
+	// Now that we have performed sanity checks and edited the filename,
+	// remove the message "body" (which was parsed into the filename) so
+	// we don't have duplicates later on.
+	rmsg.Text = ""
+
 	// TODO: add attachment ID?
-	err := b.AddAttachmentFromProtectedURL(rmsg, name, "", "", url)
+	err := b.AddAttachmentFromProtectedURL(rmsg, name, "", caption, url)
 	if err != nil {
 		return err
 	}

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -757,7 +757,6 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 		ok                        bool
 		url, name, msgtype, mtype string
 		info                      map[string]interface{}
-		size                      float64
 	)
 
 	rmsg.Extra = make(map[string][]interface{})
@@ -772,10 +771,6 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 
 	if info, ok = content.Raw["info"].(map[string]any); !ok {
 		return fmt.Errorf("info isn't a %T", info)
-	}
-
-	if size, ok = info["size"].(float64); !ok {
-		return fmt.Errorf("size isn't a %T", size)
 	}
 
 	if name, ok = content.Raw["body"].(string); !ok {

--- a/changelog.md
+++ b/changelog.md
@@ -49,7 +49,10 @@
     the return code is not 200 to avoid saving trash data ([#20](https://github.com/matterbridge-org/matterbridge/pull/20))
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
-  - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges
+  - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
+  - attachment filenames without extension how have an extension added according to mimetype, even when they're not images ;
+    when they are images, it's no longer assumed that they are PNG ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
+  - attachments with an unknown mimetype are discarded to avoid producing more errors further down ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth

--- a/changelog.md
+++ b/changelog.md
@@ -49,7 +49,7 @@
     the return code is not 200 to avoid saving trash data ([#20](https://github.com/matterbridge-org/matterbridge/pull/20))
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
-  - image attachments are now send as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
+  - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth
 - telegram

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@
     the return code is not 200 to avoid saving trash data ([#20](https://github.com/matterbridge-org/matterbridge/pull/20))
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
+  - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges
   - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth


### PR DESCRIPTION
@poVoq @josephcrowell

Three small fixes in here. We may have differing opinion about these so feedback is welcome.

- Don't check attachment size announced in attachment payload (the HTTP server will be the ultimate source of truth)
- Treat message body, when there is an attachment, as an attachment caption because that's apparently what clients do and it was producing weird results in other bridges (such as @poVoq's empty message in #23)
- If an extension matching the mimetype isn't found, add it (even if it's not an image) ; if the mimetype doesn't match any extensions, drop the attachment entirely to avoid errors further down