### PR TITLE
discord: strip short-lived URL, pass attachment as raw bytes

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -211,7 +211,9 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 	go func() {
 		count := 0
 		for _, attach := range m.Attachments {
-			err := b.AddAttachmentFromURL(&rmsg, attach.Filename, attach.ID, "", attach.URL)
+			// The URL isn't technically private, but it's short-lived so we
+			// strip it so other networks don't rely on it (attachment passed as bytes).
+			err := b.AddAttachmentFromProtectedURL(&rmsg, attach.Filename, attach.ID, "", attach.URL)
 			if err != nil {
 				b.Log.WithError(err).Warnf("Failed to download attachment %s", attach.Filename)
 				continue

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,9 @@
 - irc: Leading colon messages are no longer doubled by default as an undocumented hack (eg `:D` -> `::D`); it's now enabled by the `DoubleColonPrefix` setting.
   If you are using this setting please help us understand the usecase by commenting
   on [issue #122](https://github.com/matterbridge-org/matterbridge/issues/122), otherwise this setting may be deprecated in the near-future.
+- discord: Attachments are now passed as raw bytes and reuploaded either to the mediaserver, or to the destination bridges,
+  as discord CDN URLs are short-lived and people from other bridges would complain about broken URLs; this means IRC users will
+  no longer receive discord attachments as URLs unless a mediaserver is configured ([#170](https://github.com/matterbridge-org/matterbridge/pull/170))
 
 ## New Features
 


### PR DESCRIPTION
People were complaining in the chat and probably in some issues that discord CDN URLs are very short-lived so they couldn't see attachments in other bridges.

This is also the problem described by @poVoq in #166.

Here we ignore discord CDN URLs entirely, downloading the bytes and passing them around, either to the mediaserver (to produce new URLs, eg. for discord) or to destination bridges for their own native file upload.