### PR TITLE
xmpp: Log server-sent message type='error' as warnings

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -291,6 +291,12 @@ func (b *Bxmpp) handleXMPP() error {
 
 		switch v := m.(type) {
 		case xmpp.Chat:
+			if v.Type == "error" {
+				b.Log.Warn("Received error message from the server")
+				b.Log.Warnf("%#v", v)
+				continue
+			}
+
 			if v.Type == "groupchat" {
 				b.Log.Debugf("== Receiving %#v", v)
 

--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
   - Supports attachments
 - xmpp
   - New and revised advanced authentication settings `UseDirectTLS`, `NoStartTls`, `NoPlain`, and `Mechanism` ([#77](https://github.com/matterbridge-org/matterbridge/pull/77))
+  - Log message type='error' as warnings for easier debugging ([#173](https://github.com/matterbridge-org/matterbridge/pull/173))
 - discord
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
   - whatsapp


### PR DESCRIPTION
This is very basic and does not address rate limiting (retry sending) but at least now it's not hidden in the sea of logs

<img width="1900" height="175" alt="image" src="https://github.com/user-attachments/assets/77b259a5-e5e5-463d-9570-dcfdb4d512f3" />
