### PR TITLE
fix: xmpp should no longer send empty messages, ever

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -142,7 +142,11 @@ func (b *Bxmpp) Send(msg config.Message) (string, error) {
 		}
 	}
 
-	// Post normal message.
+	// Post normal message, if it's not empty.
+	if msg.Text == "" {
+		return "", nil
+	}
+
 	b.Log.Debugf("=> Sending message %#v", msg)
 	if _, err := b.xc.Send(xmpp.Chat{
 		Type:   "groupchat",


### PR DESCRIPTION
This should not happen, but after filtering messages in #175 i ended up with a message with just the username. It wasn't the file upload being announced but rather that after no attachments were found, we didn't check if the `Text` was empty.

This should not happen because the gateway should make sure a bridge doesn't receive a message with no text and no attachments. Maybe this should be fixed in #175 instead.