### PR TITLE
matrix: Allow unknown attachment mimetypes with custom extensions (pa…

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -792,24 +793,40 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 	// If the mime library can't guess an appropriate extension for that
 	// content-type, we're not going to deal with that content because other
 	// bridges will have problems too.
-	mext, err := mime.ExtensionsByType(mtype)
-	if err != nil {
-		return err
-	}
+	//
+	// TODO: This needs further discussion as it is a breaking change that broke
+	// user workflows, see https://github.com/matterbridge-org/matterbridge/issues/178
+	//
+	// mext, err := mime.ExtensionsByType(mtype)
+	// if err != nil {
+	// 	return err
+	// }
 
 	// Make sure file has an extension matching the mimetype.
-	foundExt := false
+	//
+	// foundExt := false
 
-	for _, ext := range mext {
-		if strings.HasSuffix(name, ext) {
-			foundExt = true
-			break
+	// for _, ext := range mext {
+	// 	if strings.HasSuffix(name, ext) {
+	// 		foundExt = true
+	// 		break
+	// 	}
+	// }
+
+	// if !foundExt {
+	// 	// No extension was found, set the first matching extension
+	// 	// according to the mime library.
+	// 	name += mext[0]
+	// }
+
+	// Until consensus emerges, we simply add an extension matching the mimetype
+	// if no extension at all was provided.
+	if path.Ext(name) == "" {
+		mext, err := mime.ExtensionsByType(mtype)
+		if err != nil {
+			return err
 		}
-	}
 
-	if !foundExt {
-		// No extension was found, set the first matching extension
-		// according to the mime library.
 		name += mext[0]
 	}
 
@@ -819,7 +836,7 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 	rmsg.Text = ""
 
 	// TODO: add attachment ID?
-	err = b.AddAttachmentFromProtectedURL(rmsg, name, "", caption, url)
+	err := b.AddAttachmentFromProtectedURL(rmsg, name, "", caption, url)
 	if err != nil {
 		return err
 	}

--- a/changelog.md
+++ b/changelog.md
@@ -55,7 +55,6 @@
   - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - attachment filenames without extension how have an extension added according to mimetype, even when they're not images ;
     when they are images, it's no longer assumed that they are PNG ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
-  - attachments with an unknown mimetype are discarded to avoid producing more errors further down ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth


### PR DESCRIPTION
This PR partially reverts #169 after discussion in #178.

Sorry for the breaking change that was not marked breaking in the changelog, and was also merged without a profound understanding of the consequences.

I still believe those mimetypes mentioned in #178 should be added to mimetype lists upstream, but in the meantime this reverts the breaking behavior.