### PR TITLE
matrix: Message body does not get dropped when there are attachments

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -383,48 +383,13 @@ func (b *Bmatrix) Send(msg config.Message) (string, error) {
 		return resp.EventID.String(), err
 	}
 
-	// Send a plain text message if html is disabled
-	if b.GetBool("HTMLDisable") {
-		var (
-			resp *mautrix.RespSendEvent
-			err  error
-		)
-
-		err = b.retry(func() error {
-			resp, err = b.mc.SendText(context.TODO(), roomID, body)
-
-			return err
-		})
-		if err != nil {
-			return "", err
-		}
-
-		return resp.EventID.String(), err
-	}
-
-	// Post normal message with HTML support (eg riot.im)
-	var (
-		resp *mautrix.RespSendEvent
-		err  error
-	)
-
-	err = b.retry(func() error {
-		content := event.MessageEventContent{
-			MsgType:       event.MsgText,
-			Body:          body,
-			FormattedBody: formattedBody,
-			Format:        event.FormatHTML,
-		}
-
-		resp, err = b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)
-
-		return err
-	})
+	// Send a normal message
+	msgID, err := b.sendNormalMessage(roomID, body, formattedBody)
 	if err != nil {
 		return "", err
 	}
 
-	return resp.EventID.String(), err
+	return msgID, nil
 }
 
 func (b *Bmatrix) NewHttpRequest(method, uri string, body io.Reader) (*http.Request, error) {
@@ -828,6 +793,21 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content event.Content
 
 // handleUploadFiles handles native upload of files.
 func (b *Bmatrix) handleUploadFiles(msg *config.Message, roomID id.RoomID) (string, error) {
+	if msg.Text != "" {
+		username := newMatrixUsername(msg.Username)
+		b.Log.Debugf("Sending text message alongside attachment from %s", username.plain)
+		body := username.plain + msg.Text
+		formattedBody := username.formatted + helper.ParseMarkdown(msg.Text)
+
+		// TODO: message ID
+		_, err := b.sendNormalMessage(roomID, body, formattedBody)
+		if err != nil {
+			// Assume if there was an error sending a simple text message,
+			// sending the attachments will not be possible.
+			return "", err
+		}
+	}
+
 	for _, f := range msg.Extra["file"] {
 		if fi, ok := f.(config.FileInfo); ok {
 			b.handleUploadFile(msg, roomID, &fi)
@@ -953,4 +933,57 @@ func (b *Bmatrix) handleUploadFile(msg *config.Message, roomID id.RoomID, fi *co
 		}
 	}
 	b.Log.Debugf("result: %#v", res)
+}
+
+func (b *Bmatrix) sendNormalMessage(roomID id.RoomID, body string, formattedBody string) (string, error) {
+	if b.GetBool("HTMLDisable") {
+		// Send a plain text message if html is disabled
+		return b.sendNormalMessagePlaintext(roomID, body)
+	} else {
+		// Post normal message with HTML support (eg riot.im)
+		return b.sendNormalMessageHTML(roomID, body, formattedBody)
+	}
+}
+
+func (b *Bmatrix) sendNormalMessagePlaintext(roomID id.RoomID, body string) (string, error) {
+	var (
+		resp *mautrix.RespSendEvent
+		err  error
+	)
+
+	err = b.retry(func() error {
+		resp, err = b.mc.SendText(context.TODO(), roomID, body)
+
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.EventID.String(), err
+}
+
+func (b *Bmatrix) sendNormalMessageHTML(roomID id.RoomID, body string, formattedBody string) (string, error) {
+	var (
+		resp *mautrix.RespSendEvent
+		err  error
+	)
+
+	err = b.retry(func() error {
+		content := event.MessageEventContent{
+			MsgType:       event.MsgText,
+			Body:          body,
+			FormattedBody: formattedBody,
+			Format:        event.FormatHTML,
+		}
+
+		resp, err = b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)
+
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.EventID.String(), err
 }

--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,7 @@
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
   - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
+  - on the other end, sending an attachment to matrix now announces the message body if there was any ([#185](https://github.com/matterbridge-org/matterbridge/pulls/185))
   - attachment filenames without extension how have an extension added according to mimetype, even when they're not images ;
     when they are images, it's no longer assumed that they are PNG ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - attachments with an unknown mimetype are discarded to avoid producing more errors further down ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))


### PR DESCRIPTION
This should fix #182 but please don't merge too quickly before testing.

Two things are happening here:

- in `handleUploadFiles` we check whether there was an actual message body and send it
- moved the simple text message sending logic to a dedicated method `sendNormalMessage` to avoid too much code repetition and to better segment the logic between HTML/plaintext