### PR TITLE
matrix: Advertise video size properly when sharing the attachment

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -892,6 +892,10 @@ func (b *Bmatrix) handleUploadFile(msg *config.Message, roomID id.RoomID, fi *co
 				MsgType:  event.MsgVideo,
 				FileName: fi.Name,
 				URL:      id.ContentURIString(res.ContentURI.String()),
+				Info: &event.FileInfo{
+					MimeType: mtype,
+					Size:     len(*fi.Data),
+				},
 			}
 
 			_, err2 := b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)

--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
     when they are images, it's no longer assumed that they are PNG ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - attachments with an unknown mimetype are discarded to avoid producing more errors further down ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
+  - video attachments advertise their size properly ([#188](https://github.com/matterbridge-org/matterbridge/pull/188)
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth
 - telegram


### PR DESCRIPTION
Attempt to fix #187 

Maybe we should modularize things into smaller functions to make it clearer.