### PR TITLE
[Added] support for FullName, FirstName, LastName, and UserName for Mattermost bridge

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -211,7 +211,9 @@ type Protocol struct {
 	UseSASL                bool       // IRC
 	UseTLS                 bool       // IRC
 	UseDiscriminator       bool       // discord
-	UseFirstName           bool       // telegram
+	UseFullName			   bool		  // mattermost
+	UseFirstName           bool       // telegram, mattermost
+	UseLastName			   bool	  	  // mattermost
 	UseUserName            bool       // discord, matrix, mattermost
 	UseInsecureURL         bool       // telegram
 	UserName               string     // IRC

--- a/bridge/mattermost/handlers.go
+++ b/bridge/mattermost/handlers.go
@@ -144,13 +144,31 @@ func (b *Bmattermost) handleMatterClient(messages chan *config.Message) {
 			}
 		}
 
-		// Use nickname instead of username if defined
-		if !b.GetBool("useusername") {
-			if nick := b.mc.GetNickName(rmsg.UserID); nick != "" {
-				rmsg.Username = nick
-			}
-		}
-
+        // Choose what to use as user nick Nickname/FullName/FirstName/LastName (or Username if neither is set)
+        if b.GetBool("UseNickName") {
+                if b.mc.GetNickName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetNickName(rmsg.UserID)
+                }
+        } else if b.GetBool("UseFirstName") {
+                if b.mc.GetFirstName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID)
+                }
+        } else if b.GetBool("UseLastName") {
+                if b.mc.GetLastName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetLastName(rmsg.UserID)
+                }
+        } else if b.GetBool("UseFullName") {
+                if b.mc.GetFirstName(rmsg.UserID) != "" && b.mc.GetLastName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID) + " " + b.mc.GetLastName(rmsg.UserID)
+                } else if b.mc.GetFirstName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID)
+                } else if b.mc.GetLastName(rmsg.UserID) != "" {
+                        rmsg.Username = b.mc.GetLastName(rmsg.UserID)
+                } else {
+                        rmsg.Username = ""
+                }
+        }
+		
 		messages <- rmsg
 	}
 }

--- a/bridge/mattermost/handlers.go
+++ b/bridge/mattermost/handlers.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/matterbridge-org/matterbridge/bridge/config"
 	"github.com/matterbridge-org/matterbridge/bridge/helper"
-	"github.com/matterbridge/matterclient"
+	"github.com/matterbridge-org/matterclient"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 

--- a/bridge/mattermost/handlers.go
+++ b/bridge/mattermost/handlers.go
@@ -145,32 +145,40 @@ func (b *Bmattermost) handleMatterClient(messages chan *config.Message) {
 		}
 
         // Choose what to use as user nick Nickname/FullName/FirstName/LastName (or Username if neither is set)
-        if b.GetBool("UseNickName") {
-                if b.mc.GetNickName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetNickName(rmsg.UserID)
-                }
-        } else if b.GetBool("UseFirstName") {
-                if b.mc.GetFirstName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID)
-                }
-        } else if b.GetBool("UseLastName") {
-                if b.mc.GetLastName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetLastName(rmsg.UserID)
-                }
-        } else if b.GetBool("UseFullName") {
-                if b.mc.GetFirstName(rmsg.UserID) != "" && b.mc.GetLastName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID) + " " + b.mc.GetLastName(rmsg.UserID)
-                } else if b.mc.GetFirstName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetFirstName(rmsg.UserID)
-                } else if b.mc.GetLastName(rmsg.UserID) != "" {
-                        rmsg.Username = b.mc.GetLastName(rmsg.UserID)
-                } else {
-                        rmsg.Username = ""
-                }
+        switch {
+        case b.GetBool("UseNickName"):
+            if nickname := b.mc.GetNickName(rmsg.UserID); nickname != "" {
+                rmsg.Username = nickname
+            }
+
+        case b.GetBool("UseFirstName"):
+            if firstname := b.mc.GetFirstName(rmsg.UserID); firstname != "" {
+                rmsg.Username = firstname
+            }
+
+        case b.GetBool("UseLastName"):
+            if lastname := b.mc.GetLastName(rmsg.UserID); lastname != "" {
+                rmsg.Username = lastname
+            }
+
+        case b.GetBool("UseFullName"):
+            first := b.mc.GetFirstName(rmsg.UserID)
+            last := b.mc.GetLastName(rmsg.UserID)
+
+            switch {
+            case first != "" && last != "":
+                rmsg.Username = first + " " + last
+            case first != "":
+                rmsg.Username = first
+            case last != "":
+                rmsg.Username = last
+            default:
+                rmsg.Username = "NoName"
+            }
         }
-		
-		messages <- rmsg
-	}
+
+        messages <- rmsg
+    }
 }
 
 func (b *Bmattermost) handleMatterHook(messages chan *config.Message) {

--- a/bridge/mattermost/helpers.go
+++ b/bridge/mattermost/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/matterbridge-org/matterbridge/bridge/config"
 	"github.com/matterbridge-org/matterbridge/bridge/helper"
 	"github.com/matterbridge-org/matterbridge/matterhook"
-	"github.com/matterbridge/matterclient"
+	"github.com/matterbridge-org/matterclient"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -11,7 +11,7 @@ import (
 	"github.com/matterbridge-org/matterbridge/bridge/config"
 	"github.com/matterbridge-org/matterbridge/bridge/helper"
 	"github.com/matterbridge-org/matterbridge/matterhook"
-	"github.com/matterbridge/matterclient"
+	"github.com/matterbridge-org/matterclient"
 	"github.com/rs/xid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/matterbridge/Rocket.Chat.Go.SDK v0.0.0-20211016222428-79310a412696
 	github.com/matterbridge/gozulipbot v0.0.0-20211023205727-a19d6c1f3b75
 	github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
-	github.com/matterbridge/matterclient v0.0.0-20240817214420-3d4c3aef3dc1
+	github.com/matterbridge-org/matterclient v0.0.1
 	github.com/matterbridge/telegram-bot-api/v6 v6.5.0
 	github.com/mattermost/mattermost/server/public v0.1.6
 	github.com/mattn/go-mastodon v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/matterbridge/gozulipbot v0.0.0-20211023205727-a19d6c1f3b75 h1:GslZKF7
 github.com/matterbridge/gozulipbot v0.0.0-20211023205727-a19d6c1f3b75/go.mod h1:yAjnZ34DuDyPHMPHHjOsTk/FefW4JJjoMMCGt/8uuQA=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba h1:XleOY4IjAEIcxAh+IFwT5JT5Ze3RHiYz6m+4ZfZ0rc0=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba/go.mod h1:iXGEotOvwI1R1SjLxRc+BF5rUORTMtE0iMZBT2lxqAU=
-github.com/matterbridge/matterclient v0.0.0-20240817214420-3d4c3aef3dc1 h1:LHzlbT3VIcRFhSPwKpZfT2TU2rUzuA8liF57gSEBuaI=
-github.com/matterbridge/matterclient v0.0.0-20240817214420-3d4c3aef3dc1/go.mod h1:quMZkUhnTp/YfbJU6sCgD6qVSPgH1Uxig9/AjgJQHF8=
+github.com/matterbridge-org/matterclient v0.0.1 h1:0Wtcf3BrOfnmWV/05mta3lagEIZy03nZAMuXbBq6r0I=
+github.com/matterbridge-org/matterclient v0.0.1/go.mod h1:qT2nKnISsB0W9feG5a1C9o0Bnye8H7lwfDEnwCA0yCs=
 github.com/matterbridge/telegram-bot-api/v6 v6.5.0 h1:wCnHWvt4WGhfognQsuu2OnHyqENBdJRf2mReYTCXggQ=
 github.com/matterbridge/telegram-bot-api/v6 v6.5.0/go.mod h1:/hSLrs8h/xNsQglQXjwXJ92iZU8XfTGkYUQ7KVDWEVo=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -409,9 +409,13 @@ SkipTLSVerify=true
 ## RELOADABLE SETTINGS
 ## Settings below can be reloaded by editing the file
 
-# UseUserName shows the username instead of the server nickname
+# Choose what use as user nick NickName/FullName/FirstName/LastName/UserName
 # OPTIONAL (default false)
-UseUserName=false
+UseNickName=false
+UseFullName=false
+UseFirstName=false
+UseLastName=false
+#if neither is set as true will use username
 
 #how to format the list of IRC nicks when displayed in mattermost.
 #Possible options are "table" and "plain"


### PR DESCRIPTION
This is my patch, rebased on top of your fork that added support for FullName, FirstName, LastName, and UserName (instead of only Nickname and FirstName).
For it to work, you will also need to apply the corresponding changes to matterclient (https://github.com/AlexanderShK/matterclient). I left the module link and checksum in go.sum and go.mod unchanged in the public repository (they would need to be updated for your fork anyway), but the patch itself is fully available and ready.

