### PR TITLE
add correct audio handling for matrix

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -931,7 +931,25 @@ func (b *Bmatrix) handleUploadFile(msg *config.Message, roomID id.RoomID, fi *co
 		})
 		if err != nil {
 			b.Log.Errorf("sendImage failed: %#v", err)
-		}
+		}                                                                                                                                                                                                                              
+	case strings.Contains(mtype, "audio") && regexp.MustCompile(`(aac|flac|matroska|mp4|mpeg|ogg|opus|vorbis)$`).MatchString(mtype): // god this is such a hack                                                                           
+         b.Log.Debugf("sendAudio %s", res.ContentURI)                                                                                                                                                                                      
+         err = b.retry(func() error {                                                                                                                                                                                                      
+             content := event.MessageEventContent{                                                                                                                                                                                         
+                 MsgType:  event.MsgAudio,                                                                                                                                                                                                 
+                 FileName: fi.Name,                                                                                                                                                                                                        
+                 URL:      id.ContentURIString(res.ContentURI.String()),                                                                                                                                                                   
+                 Info: &event.FileInfo{                                                                                                                                                                                                    
+                     MimeType: mtype,                                                                                                                                                                                                      
+                     Size:     len(*fi.Data),                                                                                                                                                                                              
+                 },                                                                                                                                                                                                                        
+             }                                                                                                                                                                                                                             
+             _, err2 := b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)                                                                                                                                         
+             return err2                                                                                                                                                                                                                   
+         })                                                                                                                                                                                                                                
+         if err != nil {                                                                                                                                                                                                                   
+             b.Log.Errorf("sendAudio failed: %#v", err)                                                                                                                                                                                    
+         }       
 	default:
 		b.Log.Debugf("sendFile %s", res.ContentURI)
 		err = b.retry(func() error {

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -931,25 +931,25 @@ func (b *Bmatrix) handleUploadFile(msg *config.Message, roomID id.RoomID, fi *co
 		})
 		if err != nil {
 			b.Log.Errorf("sendImage failed: %#v", err)
-		}                                                                                                                                                                                                                              
-	case strings.Contains(mtype, "audio") && regexp.MustCompile(`(aac|flac|matroska|mp4|mpeg|ogg|opus|vorbis|wav)$`).MatchString(mtype): // god this is such a hack                                                                           
-         b.Log.Debugf("sendAudio %s", res.ContentURI)                                                                                                                                                                                      
-         err = b.retry(func() error {                                                                                                                                                                                                      
-             content := event.MessageEventContent{                                                                                                                                                                                         
-                 MsgType:  event.MsgAudio,                                                                                                                                                                                                 
-                 FileName: fi.Name,                                                                                                                                                                                                        
-                 URL:      id.ContentURIString(res.ContentURI.String()),                                                                                                                                                                   
-                 Info: &event.FileInfo{                                                                                                                                                                                                    
-                     MimeType: mtype,                                                                                                                                                                                                      
-                     Size:     len(*fi.Data),                                                                                                                                                                                              
-                 },                                                                                                                                                                                                                        
-             }                                                                                                                                                                                                                             
-             _, err2 := b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)                                                                                                                                         
-             return err2                                                                                                                                                                                                                   
-         })                                                                                                                                                                                                                                
-         if err != nil {                                                                                                                                                                                                                   
-             b.Log.Errorf("sendAudio failed: %#v", err)                                                                                                                                                                                    
-         }       
+		}
+	case strings.Contains(mtype, "audio") && regexp.MustCompile(`(aac|flac|matroska|mp4|mpeg|ogg|opus|vorbis|wav)$`).MatchString(mtype): // god this is such a hack
+		b.Log.Debugf("sendAudio %s", res.ContentURI)
+		err = b.retry(func() error {
+			content := event.MessageEventContent{
+				MsgType:  event.MsgAudio,
+				FileName: fi.Name,
+				URL:      id.ContentURIString(res.ContentURI.String()),
+				Info: &event.FileInfo{
+					MimeType: mtype,
+					Size:     len(*fi.Data),
+				},
+			}
+			_, err2 := b.mc.SendMessageEvent(context.TODO(), roomID, event.EventMessage, content)
+			return err2
+		})
+		if err != nil {
+			b.Log.Errorf("sendAudio failed: %#v", err)
+		}
 	default:
 		b.Log.Debugf("sendFile %s", res.ContentURI)
 		err = b.retry(func() error {

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -932,7 +932,7 @@ func (b *Bmatrix) handleUploadFile(msg *config.Message, roomID id.RoomID, fi *co
 		if err != nil {
 			b.Log.Errorf("sendImage failed: %#v", err)
 		}                                                                                                                                                                                                                              
-	case strings.Contains(mtype, "audio") && regexp.MustCompile(`(aac|flac|matroska|mp4|mpeg|ogg|opus|vorbis)$`).MatchString(mtype): // god this is such a hack                                                                           
+	case strings.Contains(mtype, "audio") && regexp.MustCompile(`(aac|flac|matroska|mp4|mpeg|ogg|opus|vorbis|wav)$`).MatchString(mtype): // god this is such a hack                                                                           
          b.Log.Debugf("sendAudio %s", res.ContentURI)                                                                                                                                                                                      
          err = b.retry(func() error {                                                                                                                                                                                                      
              content := event.MessageEventContent{                                                                                                                                                                                         

--- a/changelog.md
+++ b/changelog.md
@@ -62,6 +62,7 @@
     when they are images, it's no longer assumed that they are PNG ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))
   - image attachments are now sent as images with more metadata ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
   - video attachments advertise their size properly ([#188](https://github.com/matterbridge-org/matterbridge/pull/188)
+  - audio attachments are properly now sent as `m.audio` for valid mimetypes ([#195](https://github.com/matterbridge-org/matterbridge/pull/195))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth
 - telegram


### PR DESCRIPTION
> This is a community managed project, meaning unless someone agrees with you, proposes an alternative solution and makes a PR for it, this will not be "fixed".

ok

-----

dirty hack for specific inclusion to fix https://github.com/matterbridge-org/matterbridge/issues/186 and compromise with https://github.com/matterbridge-org/matterbridge/pull/45

this was tested with the following filetypes going from discord to matrix:
- .aac  [sent as m.audio, expected]
- .flac [sent as m.audio, expected]
- .wav  [sent as m.audio, expected]
- .mid  [sent as m.file, expected]
- .s3m  [sent as m.file, expected]