### PR TITLE
discord: Ignore old message edits

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -139,6 +139,7 @@ type Protocol struct {
 	DisableWebPagePreview  bool     // telegram
 	EditSuffix             string   // mattermost, slack, discord, telegram
 	EditDisable            bool     // mattermost, slack, discord, telegram
+	EditMaxDays            int      // discord
 	HTMLDisable            bool     // matrix
 	IconURL                string   // mattermost, slack
 	IgnoreFailureOnStart   bool     // general

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -2,6 +2,7 @@ package bdiscord
 
 import (
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/davecgh/go-spew/spew"
@@ -74,7 +75,13 @@ func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdat
 		return
 	}
 	// only when message is actually edited
-	if m.Message.EditedTimestamp != nil {
+	if m.EditedTimestamp != nil {
+		// message must have been edited within EditMaxDays
+		// (there is a discord glitch where old message edits get sent without user interaction)
+		if b.GetInt("EditMaxDays") != 0 && time.Since(*m.EditedTimestamp) >= time.Duration(b.GetInt("EditMaxDays"))*24*time.Hour {
+			return
+		}
+
 		b.Log.Debugf("Sending edit message")
 		m.Content += b.GetString("EditSuffix")
 		msg := &discordgo.MessageCreate{

--- a/changelog.md
+++ b/changelog.md
@@ -42,8 +42,9 @@
   - Can now receive and download OOB attachments from XMPP channels to share with other bridges ([#23](https://github.com/matterbridge-org/matterbridge/pull/23/))
 - discord
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
-  - whatsapp
-    - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings
+  - New setting `EditMaxDays` to ignore edits of older messages. ([#199](https://github.com/matterbridge-org/matterbridge/pull/199))
+- whatsapp
+  - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings
 - slack
   - added support for using socket mode Events API to receive messages for bridging instead of RTM.
     this allows new slack bridge to be set up using modern slack apps and its tokens; see the slack docs for setup instructions ([#149](https://github.com/matterbridge-org/matterbridge/pull/149)).  

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,6 +35,16 @@ Example:
 
 `EditSuffix=" (edited)"`
 
+## EditMaxDays
+Edits of messages older than this number of days are ignored. The default of 0 disables this.
+So far only works for discord.
+
+Setting: OPTIONAL, RELOADABLE \
+Format: int \
+Example: ignore edits of messages older than 2 weeks
+
+`EditMaxDays=14`
+
 ## IgnoreMessages
 Messages you want to ignore.\
 Messages matching these regexp will be ignored and not sent to other bridges.\

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -875,6 +875,10 @@ EditDisable=false
 # Example: " (edited)"
 EditSuffix=""
 
+# Edits of messages older than this number of days are ignored.
+# OPTIONAL (default 0 - disabled)
+EditMaxDays=0
+
 # IgnoreNicks mutes outgoing messages from certain users.
 # Messages from these users will not be transmitted to other bridges.
 # Regular expressions are also supported.


### PR DESCRIPTION
Since discord occasionally sends spurious message edits for old messages make it possible to ignore those older than MaxEditDays.

Based on https://github.com/42wim/matterbridge/pull/2239/changes and discussion in #132.