### PR TITLE
irc: Deprecate `MessageSplit`/`MessageClipped` to avoid double splitting

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -160,7 +160,6 @@ type Protocol struct {
 	MessageFormat          string     // telegram
 	MessageLength          int        // IRC, max length of a message allowed
 	MessageQueue           int        // IRC, size of message queue for flood control
-	MessageSplit           bool       // IRC, split long messages with newlines on MessageLength instead of clipping
 	MessageSplitMaxCount   int        // discord, split long messages into at most this many messages instead of clipping (MessageLength=1950 cannot be configured)
 	Muc                    string     // xmpp
 	MxID                   string     // matrix

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge"
 	"github.com/matterbridge-org/matterbridge/bridge/config"
-	"github.com/matterbridge-org/matterbridge/bridge/helper"
 	stripmd "github.com/writeas/go-strip-markdown"
 
 	// We need to import the 'data' package as an implicit dependency.
@@ -166,25 +165,11 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		return "", nil
 	}
 
-	var msgLines []string
 	if b.GetBool("StripMarkdown") {
 		msg.Text = stripmd.Strip(msg.Text)
 	}
 
-	if b.GetBool("MessageSplit") {
-		msgLines = helper.GetSubLines(msg.Text, b.MessageLength, b.GetString("MessageClipped"))
-	} else {
-		msgLines = helper.GetSubLines(msg.Text, 0, b.GetString("MessageClipped"))
-	}
-	for i := range msgLines {
-		if len(b.Local) >= b.MessageQueue {
-			b.Log.Debugf("flooding, dropping message (queue at %d)", len(b.Local))
-			return "", nil
-		}
-
-		msg.Text = msgLines[i]
-		b.Local <- msg
-	}
+	b.Local <- msg
 	return "", nil
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
   - steam protocol has changed profoundly
   - keybase has been removed because we don't have a maintainer for it. See
     [issue #9](https://github.com/matterbridge-org/matterbridge/issues/9)
+- irc: the `MessageSplit` and `MessageClipped` config options have been deprecated, because message splitting has been enabled by default upstream in girc; see [#190](https://github.com/matterbridge-org/matterbridge/issues/190#issuecomment-4230431653) for more information)
 - matrix: Change to mautrix.go for the matrix backend. See ([pr #79](https://github.com/matterbridge-org/matterbridge/pull/79)/[issue #60](https://github.com/matterbridge-org/matterbridge/issues/60)
 - xmpp: Initial replies/edits support has been removed, because it was incorrect ([#12](https://github.com/matterbridge-org/matterbridge/pull/12))
 - xmpp: `NoTls` setting has been deprecated; to disable `StartTls` and start a plaintext connection, use `NoStartTls`

--- a/docs/protocols/irc/settings.md
+++ b/docs/protocols/irc/settings.md
@@ -93,17 +93,6 @@ messages will be dropped.
   MessageQueue=30
   ```
 
-## MessageSplit
-Split messages on `MessageLength` instead of showing the `<message clipped>`
-WARNING: this could lead to flooding
-
-- Setting: **OPTIONAL**, **RELOADABLE**
-- Format: *boolean*
-- Example:
-  ```toml
-  MessageSplit=true
-  ```
-
 ## Nick *
 Your nick on irc. 
 

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -105,15 +105,6 @@ MessageQueue=30
 #OPTIONAL (default 400)
 MessageLength=400
 
-#Split messages on MessageLength instead of showing the <clipped message>
-#WARNING: this could lead to flooding
-#OPTIONAL (default false)
-MessageSplit=false
-
-#Message to show when a message is too big
-#Default "<clipped message>"
-MessageClipped="<clipped message>"
-
 #Delay in seconds to rejoin a channel when kicked
 #OPTIONAL (default 0)
 RejoinDelay=0


### PR DESCRIPTION
See #190