### PR TITLE
Add CustomStatus option for Discord

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -133,6 +133,7 @@ type Protocol struct {
 	Charset                string   // irc
 	ClientID               string   // msteams
 	ColorNicks             bool     // only irc for now
+	CustomStatus           string   // discord
 	Debug                  bool     // general
 	DebugLevel             int      // only for irc now
 	DeviceID               string   // matrix

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -146,6 +146,14 @@ func (b *Bdiscord) Connect() error {
 		return err
 	}
 
+	customStatus := b.GetString("CustomStatus")
+	if customStatus != "" {
+		err = b.c.UpdateCustomStatus(customStatus)
+		if err != nil {
+			b.Log.Warnf("Error while setting custom activity status: %s", err)
+		}
+	}
+
 	// Legacy note: WebhookURL used to have an actual webhook URL that we would edit,
 	// but we stopped doing that due to Discord making rate limits more aggressive.
 	//

--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 - discord
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
   - New setting `EditMaxDays` to ignore edits of older messages. ([#199](https://github.com/matterbridge-org/matterbridge/pull/199))
+  - New setting `CustomStatus` to set the bridge bot's activity status message on Discord. ([#204](https://github.com/matterbridge-org/matterbridge/pull/204))
 - whatsapp
   - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings
 - slack

--- a/docs/protocols/discord/settings.md
+++ b/docs/protocols/discord/settings.md
@@ -30,6 +30,18 @@ permission.
   Token="YOUR_TOKEN_HERE"
   ```
 
+## CustomStatus
+
+Custom activity status message to set when connecting the bot to Discord. This
+will be shown in member lists on Discord, as well as the bot's profile.
+
+- Setting: **OPTIONAL**
+- Format: *string*
+- Example:
+  ```toml
+  CustomStatus="Bridging your chats"
+  ```
+
 ## AllowMention
 
 AllowMention controls which mentions are allowed.

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -834,6 +834,9 @@ Token="Yourtokenhere"
 # Server (REQUIRED) is the ID or name of the guild to connect to, selected from the guilds the bot has been invited to
 Server="yourservername"
 
+# CustomStatus sets a custom activity message on connect, shown in Discord member lists and the bot's profile.
+CustomStatus="Bridging your chats"
+
 ## RELOADABLE SETTINGS
 ## All settings below can be reloaded by editing the file.
 ## They are also all optional.


### PR DESCRIPTION
This allows setting a custom activity status message that will be shown on the Discord side in the bot's profile and in user lists.

<img width="209" height="76" alt="image" src="https://github.com/user-attachments/assets/3872adb8-e634-463b-925c-6143be823ab3" />

```toml
[discord]

[discord.testguild]
CustomStatus="watching your chats"
```

Strictly speaking, this is a purely cosmetic feature. Bot operators may potentially set a more helpful message pointing to a channel or page describing the bot's purpose, for example.
