### PR TITLE
fix #197

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -501,7 +501,7 @@ func (b *Bmatrix) handleEdit(ev *event.Event, rmsg config.Message) bool {
 func (b *Bmatrix) handleReply(ev *event.Event, rmsg config.Message) bool {
 	relation := ev.Content.AsMessage().OptionalGetRelatesTo()
 
-	if relation == nil {
+	if relation == nil || relation.InReplyTo == nil || relation.InReplyTo.EventID == "" {
 		return false
 	}
 


### PR DESCRIPTION
all this does is add some more conditions to an if statement.

sable adds an empty `"m.relates_to": {}` field for whatever reason when an attachment is sent without text. this crashes matterbridge. fixes #197 