### PR TITLE
irc: colornicks feature now individually colors space-delimited fields of RemoteNickFormat

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -213,7 +213,7 @@ func (b *Birc) doConnect() {
 // Sanitize nicks for RELAYMSG: replace IRC characters with special meanings with "-"
 func sanitizeNick(nick string) string {
 	sanitize := func(r rune) rune {
-		if strings.ContainsRune("!+%@&#$:'\"?*,. ", r) || r == '\00A0' { // include check for NBSP
+		if strings.ContainsRune("!+%@&#$:'\"?*,. ", r) || r == '\u00A0' { // include check for NBSP
 			return '-'
 		}
 		return r

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	
+
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge"
 	"github.com/matterbridge-org/matterbridge/bridge/config"

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -11,7 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"unicode"
+	
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge"
 	"github.com/matterbridge-org/matterbridge/bridge/config"
@@ -255,7 +256,9 @@ func (b *Birc) doSend() {
 		} else {
 			if b.GetBool("Colornicks") {
 				// Separate colors for different fields (label, proto, nick, etc)
-				userslice := strings.Fields(msg.Username)
+				userslice := strings.FieldsFunc(msg.Username, func(r rune) bool {
+					return unicode.IsSpace(r) && r != '\u00A0' // treat NBSP's as non-whitespace
+				})
 				username = ""
 				for i := range userslice {
 					checksum := crc32.ChecksumIEEE([]byte(userslice[i]))

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -213,7 +213,7 @@ func (b *Birc) doConnect() {
 // Sanitize nicks for RELAYMSG: replace IRC characters with special meanings with "-"
 func sanitizeNick(nick string) string {
 	sanitize := func(r rune) rune {
-		if strings.ContainsRune("!+%@&#$:'\"?*,. ", r) {
+		if strings.ContainsRune("!+%@&#$:'\"?*,. ", r) || r == '\00A0' { // include check for NBSP
 			return '-'
 		}
 		return r

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -257,7 +257,7 @@ func (b *Birc) doSend() {
 				// Separate colors for different fields (label, proto, nick, etc)
 				userslice := strings.Fields(msg.Username)
 				username = ""
-				for i := range len(userslice) {
+				for i := range userslice {
 					checksum := crc32.ChecksumIEEE([]byte(userslice[i]))
 					colorCode := checksum%14 + 2 // prevent white or black color codes
 					username += fmt.Sprintf("\x03%02d%s\x0F ", colorCode, userslice[i])

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge"
@@ -257,7 +256,7 @@ func (b *Birc) doSend() {
 			if b.GetBool("Colornicks") {
 				// Separate colors for different fields (label, proto, nick, etc)
 				userslice := strings.FieldsFunc(msg.Username, func(r rune) bool {
-					return unicode.IsSpace(r) && r != '\u00A0' // treat NBSP's as non-whitespace
+					return r == '\u0020' // split only on regular space; ignore NBSP, tab, newline
 				})
 				username = ""
 				for i := range userslice {

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -256,13 +256,11 @@ func (b *Birc) doSend() {
 			if b.GetBool("Colornicks") {
 				// Separate colors for different fields (label, proto, nick, etc)
 				userslice := strings.Fields(msg.Username)
-				slice1 := ""
 				username = ""
-				for i := 0; i < len(userslice); i++ {
-					slice1 = fmt.Sprintf("%s", userslice[i])
-					checksum := crc32.ChecksumIEEE([]byte(slice1))
+				for i := range len(userslice) {
+					checksum := crc32.ChecksumIEEE([]byte(userslice[i]))
 					colorCode := checksum%14 + 2 // prevent white or black color codes
-					username = username + fmt.Sprintf("\x03%02d%s\x0F ", colorCode, userslice[i])
+					username += fmt.Sprintf("\x03%02d%s\x0F ", colorCode, userslice[i])
 				}
 			}
 			switch msg.Event {

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -254,9 +254,16 @@ func (b *Birc) doSend() {
 			}
 		} else {
 			if b.GetBool("Colornicks") {
-				checksum := crc32.ChecksumIEEE([]byte(msg.Username))
-				colorCode := checksum%14 + 2 // quick fix - prevent white or black color codes
-				username = fmt.Sprintf("\x03%02d%s\x0F", colorCode, msg.Username)
+				// Separate colors for different fields (label, proto, nick, etc)
+				userslice := strings.Fields(msg.Username)
+				slice1 := ""
+				username = ""
+				for i := 0; i < len(userslice); i++ {
+					slice1 = fmt.Sprintf("%s", userslice[i])
+					checksum := crc32.ChecksumIEEE([]byte(slice1))
+					colorCode := checksum%14 + 2 // prevent white or black color codes
+					username = username + fmt.Sprintf("\x03%02d%s\x0F ", colorCode, userslice[i])
+				}
 			}
 			switch msg.Event {
 			case config.EventUserAction:

--- a/bridge/xmpp/handler.go
+++ b/bridge/xmpp/handler.go
@@ -13,10 +13,11 @@ import (
 // sends a EVENT_AVATAR_DOWNLOAD message to the gateway if successful.
 // logs an error message if it fails
 func (b *Bxmpp) handleDownloadAvatar(avatar xmpp.AvatarData) {
+	_, rchan := b.parseJID(avatar.From)
 	rmsg := config.Message{
 		Username: "system",
 		Text:     "avatar",
-		Channel:  b.parseChannel(avatar.From),
+		Channel:  rchan,
 		Account:  b.Account,
 		UserID:   avatar.From,
 		Event:    config.EventAvatarDownload,

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -320,10 +320,11 @@ func (b *Bxmpp) handleXMPP() error {
 					avatar = getAvatar(b.avatarMap, v.Remote, b.General)
 				}
 
+				rnick, rchan := b.parseJID(v.Remote)
 				rmsg := config.Message{
-					Username: b.parseNick(v.Remote),
+					Username: rnick,
 					Text:     v.Text,
-					Channel:  b.parseChannel(v.Remote),
+					Channel:  rchan,
 					Account:  b.Account,
 					Avatar:   avatar,
 					UserID:   v.Remote,
@@ -450,27 +451,6 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 		rchan = remote[:s]
 	}
 	return rnick, rchan
-}
-
-// deprecated
-func (b *Bxmpp) parseNick(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) > 1 {
-		s = strings.Split(s[1], "/")
-		if len(s) == 2 {
-			return s[1] // nick
-		}
-	}
-	return ""
-}
-
-// deprecated
-func (b *Bxmpp) parseChannel(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) >= 2 {
-		return s[0] // channel
-	}
-	return ""
 }
 
 // skipMessage skips messages that need to be skipped

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -431,29 +431,32 @@ func (b *Bxmpp) replaceAction(text string) (string, bool) {
 	return text, false
 }
 
-func (b *Bxmpp) parseNick(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) > 1 {
-		s = strings.Split(s[1], "/")
-		if len(s) == 2 {
-			return s[1] // nick
+// inspired by splitString() in mellium's jid.go
+//
+// only supports MUC JID formats (i.e. channel@server/nick) where the server is the only required part for a valid JID
+// "@" and "/" are allowed in the nick.  would need reworking to support MIX format
+func (b *Bxmpp) parseJID(remote string) (string, string) {
+	rnick, rchan := "", ""
+	s := strings.Index(remote, "/")
+	if s != -1 { // nick field (resourcepart) exists
+		if s != len(remote)-1 { // nick isn't empty
+			rnick = remote[s+1:]
+			remote = remote[:s]
 		}
 	}
-	return ""
-}
-
-func (b *Bxmpp) parseChannel(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) >= 2 {
-		return s[0] // channel
+	
+	s = strings.Index(remote, "@")
+	if s > 0 { // -1 means no localpart, 0 meas invalid empty localpart, anything else is the channel name
+		rchan = remote[:s]
 	}
-	return ""
+	return rnick, rchan
 }
 
 // skipMessage skips messages that need to be skipped
 func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	// skip messages from ourselves
-	if b.parseNick(message.Remote) == b.GetString("Nick") {
+	rnick, _ := b.parseJID(message.Remote)
+	if rnick == b.GetString("Nick") {
 		return true
 	}
 

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -452,6 +452,27 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 	return rnick, rchan
 }
 
+// deprecated
+func (b *Bxmpp) parseNick(remote string) string {
+	s := strings.Split(remote, "@")
+	if len(s) > 1 {
+		s = strings.Split(s[1], "/")
+		if len(s) == 2 {
+			return s[1] // nick
+		}
+	}
+	return ""
+}
+
+// deprecated
+func (b *Bxmpp) parseChannel(remote string) string {
+	s := strings.Split(remote, "@")
+	if len(s) >= 2 {
+		return s[0] // channel
+	}
+	return ""
+}
+
 // skipMessage skips messages that need to be skipped
 func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	// skip messages from ourselves

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -446,7 +446,7 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 	}
 	
 	s = strings.Index(remote, "@")
-	if s > 0 { // -1 means no localpart, 0 meas invalid empty localpart, anything else is the channel name
+	if s > 0 { // -1 means no localpart, 0 means invalid empty localpart, anything else is the channel name
 		rchan = remote[:s]
 	}
 	return rnick, rchan

--- a/changelog.md
+++ b/changelog.md
@@ -67,6 +67,7 @@
   - audio attachments are properly now sent as `m.audio` for valid mimetypes ([#195](https://github.com/matterbridge-org/matterbridge/pull/195))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth
+  - xmpp JID's with "@" or "/" characters in the nick will now be parsed correctly ([#216](https://github.com/matterbridge-org/matterbridge/pull/216))
 - telegram
   - OGG Vorbis attachments are now sent as audio or document to prevent confusion being received as a corrupted voice message
   - attachments of mixed types in the same message will be uploaded as documents

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 - irc: Leading colon messages are no longer doubled by default as an undocumented hack (eg `:D` -> `::D`); it's now enabled by the `DoubleColonPrefix` setting.
   If you are using this setting please help us understand the usecase by commenting
   on [issue #122](https://github.com/matterbridge-org/matterbridge/issues/122), otherwise this setting may be deprecated in the near-future.
+- irc: Destination bridges which have `Colornicks` set, and are not using `StripNick`, when receiving from bridges that allow spaces in the nickname (e.g. Discord, XMPP), will see those spaces in the nick replaced with non-breaking spaces.  This is to facilitate using any other regular whitespace characters as delimiters for the new `Colornicks` behavior ([#214](https://github.com/matterbridge-org/matterbridge/pull/214)).
 
 ## New Features
 

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,8 @@
   - new HTTP helpers are common to all bridges, and allow overriding specific settings ([#59](https://github.com/matterbridge-org/matterbridge/pull/59))
   - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
   - Docker images are now automatically built and published to `ghcr.io/matterbridge-org/matterbridge` ([#86](https://github.com/matterbridge-org/matterbridge/pull/86))
+- irc
+  - matterbridge when using the `Colornicks` setting now colors different parameters of the `RemoteNickFormat` settings individually, allowing nicks, protocols, bridge names, channels, etc. to each have a consistent color ([#214](https://github.com/matterbridge-org/matterbridge/pull/214))
 - mastodon
   - Add new Mastodon bridge ([#14](https://github.com/matterbridge-org/matterbridge/pull/14)/[#16](https://github.com/matterbridge-org/matterbridge/pull/16), thanks @lil5)
   - Supports public messages and private messages

--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@
   - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
   - Docker images are now automatically built and published to `ghcr.io/matterbridge-org/matterbridge` ([#86](https://github.com/matterbridge-org/matterbridge/pull/86))
 - irc
-  - matterbridge when using the `Colornicks` setting now colors different parameters of the `RemoteNickFormat` settings individually, allowing nicks, protocols, bridge names, channels, etc. to each have a consistent color ([#214](https://github.com/matterbridge-org/matterbridge/pull/214))
+  - matterbridge when using the `Colornicks` setting now colors any space-delimited parts of the `RemoteNickFormat` setting individually, allowing nicks, protocols, bridge names, channels, etc. to each have a consistent color ([#214](https://github.com/matterbridge-org/matterbridge/pull/214))
 - mastodon
   - Add new Mastodon bridge ([#14](https://github.com/matterbridge-org/matterbridge/pull/14)/[#16](https://github.com/matterbridge-org/matterbridge/pull/16), thanks @lil5)
   - Supports public messages and private messages

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -341,6 +341,8 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 	if dest.GetBool("StripNick") {
 		re := regexp.MustCompile("[^a-zA-Z0-9]+")
 		msg.Username = re.ReplaceAllString(msg.Username, "")
+	} else if dest.GetBool("Colornicks") { // Replace spaces with NBSP's to facilitate coloring the whole nick the same way
+		msg.Username = strings.ReplaceAll(msg.Username, " ", "\u00A0")
 	}
 	nick := dest.GetString("RemoteNickFormat")
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -338,10 +338,10 @@ func (gw *Gateway) ignoreFilesComment(extra map[string][]interface{}, igMessages
 }
 
 func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) string {
-	if dest.GetBool("StripNick") {
+	if dest.GetBool("StripNick") { // Sanitize nick so that it contains nothing but alphanumeric characters
 		re := regexp.MustCompile("[^a-zA-Z0-9]+")
 		msg.Username = re.ReplaceAllString(msg.Username, "")
-	} else if dest.GetBool("Colornicks") { // Replace spaces with NBSP's to facilitate coloring the whole nick the same way
+	} else if dest.GetBool("Colornicks") { // If we didn't strip the nick, swap any spaces with NBSP's to prevent them being treated as delimiters
 		msg.Username = strings.ReplaceAll(msg.Username, " ", "\u00A0")
 	}
 	nick := dest.GetString("RemoteNickFormat")


### PR DESCRIPTION
This will colorize different fields of the `RemoteNickFormat` string separately (e.g. label, protocol, nick, channel, etc.).  This only functions when there are spaces in the format which separate the fields.

This allows for the same nick, label, or other space-separated field to have a consistent color, no matter what other fields are included in the string.

Incoming messages from bridges that allow spaces in the nicknames (such as Discord or XMPP) will have any such spaces replaced with non-breaking spaces, which are then ignored by the `Colornicks` logic.

In order to avoid mangling such nicks for any subsequent bridges, something like ([this patch](https://github.com/42wim/matterbridge/pull/2044)) should probably be considered.