### PR TITLE
fix: set a default RemoteNickFormat for General config section

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -359,6 +359,7 @@ func NewConfigFromString(rootLogger *logrus.Logger, input []byte) Config {
 
 func newConfigFromString(logger *logrus.Entry, input []byte, cfgtype string) *config {
 	viper.SetConfigType(cfgtype)
+	viper.SetDefault("General.RemoteNickFormat", "[{PROTOCOL}] <{NICK}> ") // fixes #162
 	viper.SetEnvPrefix("matterbridge")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
   - new HTTP helpers are common to all bridges, and allow overriding specific settings ([#59](https://github.com/matterbridge-org/matterbridge/pull/59))
   - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
   - Docker images are now automatically built and published to `ghcr.io/matterbridge-org/matterbridge` ([#86](https://github.com/matterbridge-org/matterbridge/pull/86))
+  - matterbridge will now apply a default `RemoteNickFormat` setting of `"[{PROTOCOL}] <{NICK}> "` which may be overridden by individual bridge settings, environment variables, or the `General` section of the config file, fulfilling the enhancement requested at ([#162](https://github.com/matterbridge-org/matterbridge/issues/162))
 - mastodon
   - Add new Mastodon bridge ([#14](https://github.com/matterbridge-org/matterbridge/pull/14)/[#16](https://github.com/matterbridge-org/matterbridge/pull/16), thanks @lil5)
   - Supports public messages and private messages

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1643,7 +1643,7 @@ RemoteNickFormat="{NICK}"
 #The string "{GATEWAY}" (case sensitive) will be replaced by the origin gateway name that is replicating the message.
 #The string "{CHANNEL}" (case sensitive) will be replaced by the origin channel name used by the bridge
 #The string "{TENGO}" (case sensitive) will be replaced by the output of the RemoteNickFormat script under [tengo]
-#OPTIONAL (default empty)
+#OPTIONAL (default "[{PROTOCOL}] <{NICK}> ")
 RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 
 #StripNick only allows alphanumerical nicks. See https://github.com/42wim/matterbridge/issues/285


### PR DESCRIPTION
This requested enhancement ([#162](https://github.com/matterbridge-org/matterbridge/issues/162)) adds a default `RemoteNickFormat`, which can be overridden by any individual bridge settings, environment variables, or the `General` section of the config file.

The `General` default is now `"[{PROTOCOL}] <{NICK}> "`, as appears to be the consensus about what this ought to be set to, and as appears repeatedly as a default in the TOML sample config file.
