### PR TITLE
fix: xmpp bridge now properly handles special chars in nicks

### DIFF
--- a/bridge/xmpp/handler.go
+++ b/bridge/xmpp/handler.go
@@ -13,10 +13,11 @@ import (
 // sends a EVENT_AVATAR_DOWNLOAD message to the gateway if successful.
 // logs an error message if it fails
 func (b *Bxmpp) handleDownloadAvatar(avatar xmpp.AvatarData) {
+	_, rchan := b.parseJID(avatar.From)
 	rmsg := config.Message{
 		Username: "system",
 		Text:     "avatar",
-		Channel:  b.parseChannel(avatar.From),
+		Channel:  rchan,
 		Account:  b.Account,
 		UserID:   avatar.From,
 		Event:    config.EventAvatarDownload,

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -320,10 +320,11 @@ func (b *Bxmpp) handleXMPP() error {
 					avatar = getAvatar(b.avatarMap, v.Remote, b.General)
 				}
 
+				rnick, rchan := b.parseJID(v.Remote)
 				rmsg := config.Message{
-					Username: b.parseNick(v.Remote),
+					Username: rnick,
 					Text:     v.Text,
-					Channel:  b.parseChannel(v.Remote),
+					Channel:  rchan,
 					Account:  b.Account,
 					Avatar:   avatar,
 					UserID:   v.Remote,
@@ -450,27 +451,6 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 		rchan = remote[:s]
 	}
 	return rnick, rchan
-}
-
-// deprecated
-func (b *Bxmpp) parseNick(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) > 1 {
-		s = strings.Split(s[1], "/")
-		if len(s) == 2 {
-			return s[1] // nick
-		}
-	}
-	return ""
-}
-
-// deprecated
-func (b *Bxmpp) parseChannel(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) >= 2 {
-		return s[0] // channel
-	}
-	return ""
 }
 
 // skipMessage skips messages that need to be skipped

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -431,29 +431,32 @@ func (b *Bxmpp) replaceAction(text string) (string, bool) {
 	return text, false
 }
 
-func (b *Bxmpp) parseNick(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) > 1 {
-		s = strings.Split(s[1], "/")
-		if len(s) == 2 {
-			return s[1] // nick
+// inspired by splitString() in mellium's jid.go
+//
+// only supports MUC JID formats (i.e. channel@server/nick) where the server is the only required part for a valid JID
+// "@" and "/" are allowed in the nick.  would need reworking to support MIX format
+func (b *Bxmpp) parseJID(remote string) (string, string) {
+	rnick, rchan := "", ""
+	s := strings.Index(remote, "/")
+	if s != -1 { // nick field (resourcepart) exists
+		if s != len(remote)-1 { // nick isn't empty
+			rnick = remote[s+1:]
+			remote = remote[:s]
 		}
 	}
-	return ""
-}
-
-func (b *Bxmpp) parseChannel(remote string) string {
-	s := strings.Split(remote, "@")
-	if len(s) >= 2 {
-		return s[0] // channel
+	
+	s = strings.Index(remote, "@")
+	if s > 0 { // -1 means no localpart, 0 meas invalid empty localpart, anything else is the channel name
+		rchan = remote[:s]
 	}
-	return ""
+	return rnick, rchan
 }
 
 // skipMessage skips messages that need to be skipped
 func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	// skip messages from ourselves
-	if b.parseNick(message.Remote) == b.GetString("Nick") {
+	rnick, _ := b.parseJID(message.Remote)
+	if rnick == b.GetString("Nick") {
 		return true
 	}
 

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -452,6 +452,27 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 	return rnick, rchan
 }
 
+// deprecated
+func (b *Bxmpp) parseNick(remote string) string {
+	s := strings.Split(remote, "@")
+	if len(s) > 1 {
+		s = strings.Split(s[1], "/")
+		if len(s) == 2 {
+			return s[1] // nick
+		}
+	}
+	return ""
+}
+
+// deprecated
+func (b *Bxmpp) parseChannel(remote string) string {
+	s := strings.Split(remote, "@")
+	if len(s) >= 2 {
+		return s[0] // channel
+	}
+	return ""
+}
+
 // skipMessage skips messages that need to be skipped
 func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	// skip messages from ourselves

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -446,7 +446,7 @@ func (b *Bxmpp) parseJID(remote string) (string, string) {
 	}
 	
 	s = strings.Index(remote, "@")
-	if s > 0 { // -1 means no localpart, 0 meas invalid empty localpart, anything else is the channel name
+	if s > 0 { // -1 means no localpart, 0 means invalid empty localpart, anything else is the channel name
 		rchan = remote[:s]
 	}
 	return rnick, rchan

--- a/changelog.md
+++ b/changelog.md
@@ -67,6 +67,7 @@
   - audio attachments are properly now sent as `m.audio` for valid mimetypes ([#195](https://github.com/matterbridge-org/matterbridge/pull/195))
 - xmpp
   - various upstream go-xmpp changes fix connection on SASL2 with PLAIN auth
+  - xmpp JID's with "@" or "/" characters in the nick will now be parsed correctly ([#216](https://github.com/matterbridge-org/matterbridge/pull/216))
 - telegram
   - OGG Vorbis attachments are now sent as audio or document to prevent confusion being received as a corrupted voice message
   - attachments of mixed types in the same message will be uploaded as documents


### PR DESCRIPTION
This bugfix ([#78](https://github.com/matterbridge-org/matterbridge/issues/78)) removes `parseNick()` and `parseChannel()` from `xmpp.go`, replacing them with a new `parseJID()` function inspired by the way mellium does it.

Since XMPP allows both "/" and "@" characters to occur in nicks, the existing functions could each parse the JID improperly:

- `parseChannel()` could fail if receiving a message where there was no localpart (channel name), but there was a "@" in the nick, which is still considered a valid JID; the only required part for a valid JID is the domainpart.

- `parseNick()` could fail if receiving either a message without a localpart, or with one or more "/" characters in the nick.
