### PR TITLE
Implement skip of encrypted XMPP messages

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -196,6 +196,7 @@ type Protocol struct {
 	ShowTopicChange        bool       // slack
 	ShowUserTyping         bool       // slack
 	ShowEmbeds             bool       // discord
+	SkipEncrypted          bool       // xmpp
 	SkipTLSVerify          bool       // IRC, mattermost
 	SkipVersionCheck       bool       // mattermost
 	StripNick              bool       // all protocols

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -450,6 +450,30 @@ func (b *Bxmpp) parseChannel(remote string) string {
 	return ""
 }
 
+// isEncrypted reports whether the message is end-to-end encrypted and therefore
+// cannot be relayed as readable text.
+func isEncrypted(message xmpp.Chat) bool {
+	// OTR rides inside the plaintext body
+	if strings.HasPrefix(message.Text, "?OTR") {
+		return true
+	}
+	for _, e := range message.OtherElem {
+		switch {
+		case e.XMLName.Local == "encrypted" &&
+			(e.XMLName.Space == "eu.siacs.conversations.axolotl" ||
+				e.XMLName.Space == "urn:xmpp:omemo:2"):
+			return true // OMEMO
+		case e.XMLName.Local == "openpgp" &&
+			e.XMLName.Space == "urn:xmpp:openpgp:0":
+			return true // OX (XEP-0373)
+		case e.XMLName.Local == "x" &&
+			e.XMLName.Space == "jabber:x:encrypted":
+			return true // legacy OpenPGP (XEP-0027)
+		}
+	}
+	return false
+}
+
 // skipMessage skips messages that need to be skipped
 func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	// skip messages from ourselves
@@ -464,6 +488,11 @@ func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 
 	// skip subject messages
 	if strings.Contains(message.Text, "</subject>") {
+		return true
+	}
+
+	// skip encrypted messages if configured to do so
+	if b.GetBool("SkipEncrypted") && isEncrypted(message) {
 		return true
 	}
 

--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@
   - Log message type='error' as warnings for easier debugging ([#173](https://github.com/matterbridge-org/matterbridge/pull/173))
   - Can now upload files from bytes in addition to sharing attachement URLs ([#23](https://github.com/matterbridge-org/matterbridge/pull/23/))
   - Can now receive and download OOB attachments from XMPP channels to share with other bridges ([#23](https://github.com/matterbridge-org/matterbridge/pull/23/))
+  - New setting `SkipEncrypted` to ignore encrypted messages (OTR, PGP, OMEMO) ([#217](https://github.com/matterbridge-org/matterbridge/pull/217/))
 - discord
   - Replies will be included inline ([#124](https://github.com/matterbridge-org/matterbridge/pull/124), thanks @lekoOwO), by default like "(re name: message)". This is useful when bridging to destinations that do not understand replies, but distracting when the destination does. Can be disabled with `QuoteDisable=true` under your `[discord]` config.
   - New setting `EditMaxDays` to ignore edits of older messages. ([#199](https://github.com/matterbridge-org/matterbridge/pull/199))

--- a/docs/protocols/xmpp/settings.md
+++ b/docs/protocols/xmpp/settings.md
@@ -61,6 +61,18 @@ Your nick in the rooms
   NoTLS=true
   ```
 
+## SkipEncrypted
+
+Do not relay encrypted messages (OTR, PGP, OMEMO).
+
+- Setting: **OPTIONAL**
+- Format: *boolean*
+- Example:
+  ```toml
+  SkipEncrypted=true
+  ```
+
+
 ## UseDirectTLS
 
 Enables direct TLS connection to your server. Most servers by default only support StartTLS,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -158,14 +158,6 @@ Example: enable it
 
 `SkipTLSVerify=true`
 
-## SkipEncrypted
-Do not relay encrypted messages (OTR, PGP, OMEMO). \
-Only supported by XMPP.
-
-Setting: OPTIONAL \
-Format: boolean \
-Example: enable it
-
 ## StripNick
 StripNick only allows alphanumerical nicks. See https://github.com/42wim/matterbridge/issues/285
 It will strip other characters from the nick

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -158,6 +158,14 @@ Example: enable it
 
 `SkipTLSVerify=true`
 
+## SkipEncrypted
+Do not relay encrypted messages (OTR, PGP, OMEMO). \
+Only supported by XMPP.
+
+Setting: OPTIONAL \
+Format: boolean \
+Example: enable it
+
 ## StripNick
 StripNick only allows alphanumerical nicks. See https://github.com/42wim/matterbridge/issues/285
 It will strip other characters from the nick

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -273,6 +273,11 @@ SkipTLSVerify=true
 #OPTIONAL (default false)
 NoTLS=true
 
+#Drop end-to-end encrypted messages (OMEMO, OTR, OpenPGP) instead of relaying
+#their unusable plaintext fallback to other bridges.
+#OPTIONAL (default false)
+SkipEncrypted=false
+
 ## RELOADABLE SETTINGS
 ## Settings below can be reloaded by editing the file
 


### PR DESCRIPTION
End-to-end encrypted XMPP messages can't be decrypted by the matterbridge yet - they get relayed to other chats as their plaintext fallback body such as "I sent you an OMEMO encrypted message but your client doesn't support that".

This change adds a boolean option SkipEncrypted for XMPP gateway with a default value false to keep current behavior unchanged.
