### PR TITLE
irc: colornicks feature now individually colors space-delimited fields of RemoteNickFormat

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -217,6 +217,7 @@ type Protocol struct {
 	UseUserName            bool       // discord, matrix, mattermost
 	UseInsecureURL         bool       // telegram
 	UserName               string     // IRC
+	UseRelayMsg            bool       // IRC
 	VerboseJoinPart        bool       // IRC
 	WebhookBindAddress     string     // mattermost, slack
 	WebhookURL             string     // mattermost, slack

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge"
@@ -213,9 +214,12 @@ func (b *Birc) doConnect() {
 }
 
 // Sanitize nicks for RELAYMSG: replace IRC characters with special meanings with "-"
-func sanitizeNick(nick string) string {
+// This only gets called when UseRelayMsg is set, and the irc server also supports RELAYMSG.
+// The list of disallowed characters is given here:
+// https://github.com/jlu5/ircv3-specifications/blob/master/extensions/relaymsg.md
+func (b *Birc) sanitizeNick(nick string) string {
 	sanitize := func(r rune) rune {
-		if strings.ContainsRune("!+%@&#$:'\"?*,. ", r) {
+		if strings.ContainsRune("!+%@&#$:'\"?*,.", r) || unicode.IsSpace(r) { // include check for any whitespace
 			return '-'
 		}
 		return r
@@ -232,44 +236,58 @@ func (b *Birc) doSend() {
 		// Optional support for the proposed RELAYMSG extension, described at
 		// https://github.com/jlu5/ircv3-specifications/blob/master/extensions/relaymsg.md
 		// nolint:nestif
-		if (b.i.HasCapability("overdrivenetworks.com/relaymsg") || b.i.HasCapability("draft/relaymsg")) &&
-			b.GetBool("UseRelayMsg") {
-			username = sanitizeNick(username)
-			text := msg.Text
+		if b.GetBool("UseRelayMsg") { // Let's check this by itself first to avoid needlessly querying the irc lib on each msg, in case it takes out any locks
+			if b.i.HasCapability("overdrivenetworks.com/relaymsg") || b.i.HasCapability("draft/relaymsg") {
+				username = b.sanitizeNick(username)
+				text := msg.Text
 
-			// Work around girc chomping leading commas on single word messages?
-			if b.GetBool("DoubleColonPrefix") {
-				if strings.HasPrefix(text, ":") && !strings.ContainsRune(text, ' ') {
-					b.Log.Warn("This option may be deprecated in the future. If you are using it, please help us understand the usecase by commenting on this issue: https://github.com/matterbridge-org/matterbridge/issues/122")
+				// Work around girc chomping leading commas on single word messages?
+				if b.GetBool("DoubleColonPrefix") {
+					if strings.HasPrefix(text, ":") && !strings.ContainsRune(text, ' ') {
+						b.Log.Warn("This option may be deprecated in the future. If you are using it, please help us understand the usecase by commenting on this issue: https://github.com/matterbridge-org/matterbridge/issues/122")
 
-					text = ":" + text
+						text = ":" + text
+					}
+				} else {
+					b.Log.Debug("Leading colon workaround has been disabled; reenable it with `DoubleColonPrefix=true`.")
 				}
-			} else {
-				b.Log.Debug("Leading colon workaround has been disabled; reenable it with `DoubleColonPrefix=true`.")
-			}
 
-			if msg.Event == config.EventUserAction {
-				b.i.Cmd.SendRawf("RELAYMSG %s %s :\x01ACTION %s\x01", msg.Channel, username, text) //nolint:errcheck
-			} else {
-				b.Log.Debugf("Sending RELAYMSG to channel %s: nick=%s", msg.Channel, username)
-				b.i.Cmd.SendRawf("RELAYMSG %s %s :%s", msg.Channel, username, text) //nolint:errcheck
+				if msg.Event == config.EventUserAction {
+					err := b.i.Cmd.SendRawf("RELAYMSG %s %s :\x01ACTION %s\x01", msg.Channel, username, text)
+					if err != nil {
+						b.Log.Warn("The RELAYMSG ACTION command failed")
+					}
+				} else {
+					b.Log.Debugf("Sending RELAYMSG to channel %s: nick=%s", msg.Channel, username)
+					err := b.i.Cmd.SendRawf("RELAYMSG %s %s :%s", msg.Channel, username, text)
+					if err != nil {
+						b.Log.Warn("The RELAYMSG command failed")
+					}
+				}
+			} else { // We have UseRelayMsg set but lack the capability.  Log a warning
+				b.Log.Warn("WARNING!  UseRelayMsg was set, but the irc server does not support it.")
 			}
-		} else {
-			if b.GetBool("Colornicks") {
-				checksum := crc32.ChecksumIEEE([]byte(msg.Username))
-				colorCode := checksum%14 + 2 // quick fix - prevent white or black color codes
-				username = fmt.Sprintf("\x03%02d%s\x0F", colorCode, msg.Username)
+		} else if b.GetBool("Colornicks") { // If we aren't using UseRelayMsg, we might be using Colornicks.  The two can't both be used.
+			// Separate colors for different fields (label, proto, nick, etc)
+			userslice := strings.FieldsFunc(msg.Username, func(r rune) bool {
+				return r == '\u0020' // split only on regular space; ignore NBSP, tab, newline
+			})
+			username = ""
+			for i := range userslice {
+				checksum := crc32.ChecksumIEEE([]byte(userslice[i]))
+				colorCode := checksum%14 + 2 // prevent white or black color codes
+				username += fmt.Sprintf("\x03%02d%s\x0F ", colorCode, userslice[i])
 			}
-			switch msg.Event {
-			case config.EventUserAction:
-				b.i.Cmd.Action(msg.Channel, username+msg.Text)
-			case config.EventNoticeIRC:
-				b.Log.Debugf("Sending notice to channel %s", msg.Channel)
-				b.i.Cmd.Notice(msg.Channel, username+msg.Text)
-			default:
-				b.Log.Debugf("Sending to channel %s", msg.Channel)
-				b.i.Cmd.Message(msg.Channel, username+msg.Text)
-			}
+		}
+		switch msg.Event {
+		case config.EventUserAction:
+			b.i.Cmd.Action(msg.Channel, username+msg.Text)
+		case config.EventNoticeIRC:
+			b.Log.Debugf("Sending notice to channel %s", msg.Channel)
+			b.i.Cmd.Notice(msg.Channel, username+msg.Text)
+		default:
+			b.Log.Debugf("Sending to channel %s", msg.Channel)
+			b.i.Cmd.Message(msg.Channel, username+msg.Text)
 		}
 	}
 }

--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,7 @@
 - general
   - when downloading a file attachment from a remote HTTP server, matterbridge will now error if
     the return code is not 200 to avoid saving trash data ([#20](https://github.com/matterbridge-org/matterbridge/pull/20))
+  - fix for upstream issue 42wim#2043 by github user adbenitez's [fork](https://github.com/adbenitez/matterbridge/tree/adb/issue-2043) which will prevent per-destination message modifications for one bridge, such as for `StripNick` or `ColorNicks`, from being incorrectly applied to the original message that will be sent to other bridges which may not be using such settings
 - matrix
   - attachments received from matrix are working again, with authenticated media (MSC3916) implemented ([#61](https://github.com/matterbridge-org/matterbridge/pull/61))
   - attachment body is treated as attachment caption and will no longer produce bogus text messages on other bridges ([#169](https://github.com/matterbridge-org/matterbridge/pull/169/))

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
   If you are using this setting please help us understand the usecase by commenting
   on [issue #122](https://github.com/matterbridge-org/matterbridge/issues/122), otherwise this setting may be deprecated in the near-future.
 - irc: Charset for irc bridges will now be set to a default of "UTF-8", to avoid mojibake when attempting to automatically guess the incoming charset.  If you want to try autodetecting, you will need to set this to "autodetect" for the irc bridge.  Ideally, you will know which charset to set and won't have to try to guess.  Even with autodetection set, UTF-8 will be checked first before trying anything else, then fall back to latin-1 if the autodetection fails.  This should mostly address ([#120](https://github.com/matterbridge-org/matterbridge/issues/120))
+- irc: Destination bridges which have `Colornicks` set, and are not using `StripNick` nor `UseRelayMsg`, when receiving from bridges that allow spaces in the nickname (e.g. Discord, XMPP), will see those spaces in the nick replaced with non-breaking spaces.  This is to facilitate using spaces as delimiters for the new `Colornicks` behavior ([#218](https://github.com/matterbridge-org/matterbridge/pull/218))
 
 ## New Features
 
@@ -33,6 +34,8 @@
   - matterbridge is now built with whatsappmulti backend enabled by default, unless the `nowhatsappmulti` build tag is passed
   - Docker images are now automatically built and published to `ghcr.io/matterbridge-org/matterbridge` ([#86](https://github.com/matterbridge-org/matterbridge/pull/86))
   - matterbridge will now apply a default `RemoteNickFormat` setting of `"[{PROTOCOL}] <{NICK}> "` which may be overridden by individual bridge settings, environment variables, or the `General` section of the config file, fulfilling the enhancement requested at ([#162](https://github.com/matterbridge-org/matterbridge/issues/162))
+- irc
+  - matterbridge when using the `Colornicks` setting now colors any space-delimited parts of the `RemoteNickFormat` setting individually, allowing nicks, protocols, bridge names, channels, etc. to each have a consistent color ([#218](https://github.com/matterbridge-org/matterbridge/pull/218))
 - mastodon
   - Add new Mastodon bridge ([#14](https://github.com/matterbridge-org/matterbridge/pull/14)/[#16](https://github.com/matterbridge-org/matterbridge/pull/16), thanks @lil5)
   - Supports public messages and private messages

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -39,47 +39,7 @@ type BrMsgID struct {
 }
 
 const apiProtocol = "api"
-
-// New creates a new Gateway object associated with the specified router and
-// following the given configuration.
-func New(rootLogger *logrus.Logger, cfg *config.Gateway, r *Router) *Gateway {
-	logger := rootLogger.WithFields(logrus.Fields{"prefix": "gateway"})
-
-	cache, _ := lru.New(5000)
-	gw := &Gateway{
-		Channels: make(map[string]*config.ChannelInfo),
-		Message:  r.Message,
-		Router:   r,
-		Bridges:  make(map[string]*bridge.Bridge),
-		Config:   r.Config,
-		Messages: cache,
-		logger:   logger,
-	}
-	if err := gw.AddConfig(cfg); err != nil {
-		logger.Errorf("Failed to add configuration to gateway: %#v", err)
-	}
-	return gw
-}
-
-// FindCanonicalMsgID returns the ID under which a message was stored in the cache.
-func (gw *Gateway) FindCanonicalMsgID(protocol string, mID string) string {
-	ID := protocol + " " + mID
-	if gw.Messages.Contains(ID) {
-		return ID
-	}
-
-	// If not keyed, iterate through cache for downstream, and infer upstream.
-	for _, mid := range gw.Messages.Keys() {
-		v, _ := gw.Messages.Peek(mid)
-		ids := v.([]*BrMsgID)
-		for _, downstreamMsgObj := range ids {
-			if ID == downstreamMsgObj.ID {
-				return mid.(string)
-			}
-		}
-	}
-	return ""
-}
+const ircProtocol = "irc"
 
 // AddBridge sets up a new bridge on startup.
 //
@@ -117,22 +77,6 @@ func (gw *Gateway) AddBridge(cfg *config.Bridge) error {
 	return nil
 }
 
-// checkConfig checks a bridge config, on startup.
-//
-// This is not triggered when config is reloaded from disk.
-func (gw *Gateway) checkConfig(cfg *config.Bridge) {
-	match := false
-	for _, key := range gw.Router.Config.Viper().AllKeys() {
-		if strings.HasPrefix(key, strings.ToLower(cfg.Account)) {
-			match = true
-			break
-		}
-	}
-	if !match {
-		gw.logger.Fatalf("Account %s defined in gateway %s but no configuration found, exiting.", cfg.Account, gw.Name)
-	}
-}
-
 // AddConfig associates a new configuration with the gateway object.
 func (gw *Gateway) AddConfig(cfg *config.Gateway) error {
 	gw.Name = cfg.Name
@@ -148,6 +92,167 @@ func (gw *Gateway) AddConfig(cfg *config.Gateway) error {
 		}
 	}
 	return nil
+}
+
+// FindCanonicalMsgID returns the ID under which a message was stored in the cache.
+func (gw *Gateway) FindCanonicalMsgID(protocol string, mID string) string {
+	ID := protocol + " " + mID
+	if gw.Messages.Contains(ID) {
+		return ID
+	}
+
+	// If not keyed, iterate through cache for downstream, and infer upstream.
+	for _, mid := range gw.Messages.Keys() {
+		v, _ := gw.Messages.Peek(mid)
+		ids, ok := v.([]*BrMsgID)
+		if !ok { // type assertion failed
+			gw.logger.Errorf("v.([]*BrMsgID) type assertion failed")
+		}
+		for _, downstreamMsgObj := range ids {
+			if ID == downstreamMsgObj.ID {
+				midstring, ok := mid.(string)
+				if !ok { // type assertion failed
+					gw.logger.Errorf("mid.(string) type assertion failed")
+				}
+				return midstring
+			}
+		}
+	}
+	return ""
+}
+
+// New creates a new Gateway object associated with the specified router and
+// following the given configuration.
+func New(rootLogger *logrus.Logger, cfg *config.Gateway, r *Router) *Gateway {
+	logger := rootLogger.WithFields(logrus.Fields{"prefix": "gateway"})
+
+	cache, _ := lru.New(5000)
+	gw := &Gateway{
+		Channels: make(map[string]*config.ChannelInfo),
+		Message:  r.Message,
+		Router:   r,
+		Bridges:  make(map[string]*bridge.Bridge),
+		Config:   r.Config,
+		Messages: cache,
+		logger:   logger,
+	}
+	err := gw.AddConfig(cfg)
+	if err != nil {
+		logger.Errorf("Failed to add configuration to gateway: %#v", err)
+	}
+	return gw
+}
+
+// SendMessage sends a message (with specified parentID) to the channel on the selected
+// destination bridge and returns a message ID or an error.
+func (gw *Gateway) SendMessage( //nolint:gocyclo,funlen
+	rmsg *config.Message,
+	dest *bridge.Bridge,
+	channel *config.ChannelInfo,
+	canonicalParentMsgID string,
+) (string, error) {
+	msg := *rmsg
+	// Only send the avatar download event to ourselves.
+	if msg.Event == config.EventAvatarDownload {
+		if channel.ID != getChannelID(rmsg) {
+			return "", nil
+		}
+	} else {
+		// do not send to ourself for any other event
+		if channel.ID == getChannelID(rmsg) {
+			return "", nil
+		}
+	}
+
+	// Too noisy to log like other events
+	debugSendMessage := ""
+
+	switch msg.Event {
+	case config.EventNoticeIRC: // Only send irc notices to IRC
+		if dest.Protocol != ircProtocol {
+			return "", nil
+		}
+	case config.EventUserTyping:
+		break
+	case config.EventFileDelete: // exclude file delete event as the msg ID here is the native file ID that needs to be deleted
+		break
+	default:
+		debugSendMessage = fmt.Sprintf("=> Sending %#v from %s (%s) to %s (%s)", msg, msg.Account, rmsg.Channel, dest.Account, channel.Name)
+		msg.ID = gw.getDestMsgID(rmsg.Protocol+" "+rmsg.ID, dest, channel)
+	}
+
+	if dest.Protocol == apiProtocol {
+		msg.Channel = rmsg.Channel // for api we need originchannel as channel
+	} else {
+		msg.Channel = channel.Name
+	}
+
+	gw.modifyAvatar(&msg, dest)
+	gw.modifyUsername(&msg, dest)
+
+	msg.ParentID = gw.getDestMsgID(canonicalParentMsgID, dest, channel)
+	if msg.ParentID == "" {
+		msg.ParentID = strings.Replace(canonicalParentMsgID, dest.Protocol+" ", "", 1)
+	}
+
+	// if the parentID is still empty and we have a parentID set in the original message
+	// this means that we didn't find it in the cache so set it to a "msg-parent-not-found" constant
+	if msg.ParentID == "" && rmsg.ParentID != "" {
+		msg.ParentID = config.ParentIDNotFound
+	}
+
+	drop, err := gw.modifyOutMessageTengo(rmsg, &msg, dest)
+	if err != nil {
+		gw.logger.Errorf("modifySendMessageTengo: %s", err)
+	}
+
+	if drop {
+		gw.logger.Debugf("=> Tengo dropping %#v from %s (%s) to %s (%s)", msg, msg.Account, rmsg.Channel, dest.Account, channel.Name)
+		return "", nil
+	}
+
+	if debugSendMessage != "" {
+		gw.logger.Debug(debugSendMessage)
+	}
+
+	// if we are using mattermost plugin account, send messages to MattermostPlugin channel
+	// that can be picked up by the mattermost matterbridge plugin
+	if dest.Account == "mattermost.plugin" {
+		gw.Router.MattermostPlugin <- msg
+	}
+
+	defer func(t time.Time) {
+		gw.logger.Debugf("=> Send from %s (%s) to %s (%s) took %s", msg.Account, rmsg.Channel, dest.Account, channel.Name, time.Since(t))
+	}(time.Now())
+
+	mID, err := dest.Send(msg)
+	if err != nil {
+		return mID, err
+	}
+
+	// append the message ID (mID) from this bridge (dest) to our brMsgIDs slice
+	// append has been moved to handlers.go
+	if mID != "" {
+		gw.logger.Debugf("mID %s: %s", dest.Account, mID)
+		return mID, nil
+	}
+	return "", nil
+}
+
+// checkConfig checks a bridge config, on startup.
+//
+// This is not triggered when config is reloaded from disk.
+func (gw *Gateway) checkConfig(cfg *config.Bridge) {
+	match := false
+	for _, key := range gw.Router.Config.Viper().AllKeys() {
+		if strings.HasPrefix(key, strings.ToLower(cfg.Account)) {
+			match = true
+			break
+		}
+	}
+	if !match {
+		gw.logger.Fatalf("Account %s defined in gateway %s but no configuration found, exiting.", cfg.Account, gw.Name)
+	}
 }
 
 func (gw *Gateway) mapChannelsToBridge(br *bridge.Bridge) {
@@ -337,10 +442,24 @@ func (gw *Gateway) ignoreFilesComment(extra map[string][]interface{}, igMessages
 	return false
 }
 
-func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) string {
-	if dest.GetBool("StripNick") {
+func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) {
+	// fix for upstream issue #2043 was written by github user adbenitez
+	// this prevents StripNick (and now also Colornicks) from being applied to the original msg,
+	// and thereby potentially affecting subsequent bridges which lack those settings.
+	// https://github.com/adbenitez/matterbridge/tree/adb/issue-2043
+	//
+	// TODO: When used, StripNick can possibly enable impersonation attacks, as a user can join the same
+	// channel with a similar nick but with a special character in it, which would then get stripped out;
+	// such would be obvious to the other local users on that channel, but from any remote bridge's point of view,
+	// the two users would have the same nick.  Perhaps we can log a warning when there is a collision like that?
+	if dest.GetBool("StripNick") { // Sanitize nick so that it contains nothing but alphanumeric characters
 		re := regexp.MustCompile("[^a-zA-Z0-9]+")
 		msg.Username = re.ReplaceAllString(msg.Username, "")
+	} else if dest.Protocol == "irc" && !dest.GetBool("UseRelayMsg") && dest.GetBool("Colornicks") {
+		// Colornicks is currently only available for IRC, but it's not compatible with Relaymsg.
+		// If we didn't strip the nick, then swap any spaces with NBSP's.
+		// This is only needed for the Colornicks setting to function.
+		msg.Username = strings.ReplaceAll(msg.Username, " ", "\u00A0")
 	}
 	nick := dest.GetString("RemoteNickFormat")
 
@@ -383,16 +502,15 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 		gw.logger.Errorf("modifyUsernameTengo error: %s", err)
 	}
 	nick = strings.ReplaceAll(nick, "{TENGO}", tengoNick)
-	return nick
+	msg.Username = nick
 }
 
-func (gw *Gateway) modifyAvatar(msg *config.Message, dest *bridge.Bridge) string {
+func (gw *Gateway) modifyAvatar(msg *config.Message, dest *bridge.Bridge) {
 	iconurl := dest.GetString("IconURL")
 	iconurl = strings.ReplaceAll(iconurl, "{NICK}", msg.Username)
 	if msg.Avatar == "" {
 		msg.Avatar = iconurl
 	}
-	return msg.Avatar
 }
 
 func (gw *Gateway) modifyMessage(msg *config.Message) {
@@ -440,100 +558,6 @@ func (gw *Gateway) modifyMessage(msg *config.Message) {
 	if msg.Protocol != apiProtocol {
 		msg.Gateway = gw.Name
 	}
-}
-
-// SendMessage sends a message (with specified parentID) to the channel on the selected
-// destination bridge and returns a message ID or an error.
-func (gw *Gateway) SendMessage(
-	rmsg *config.Message,
-	dest *bridge.Bridge,
-	channel *config.ChannelInfo,
-	canonicalParentMsgID string,
-) (string, error) {
-	msg := *rmsg
-	// Only send the avatar download event to ourselves.
-	if msg.Event == config.EventAvatarDownload {
-		if channel.ID != getChannelID(rmsg) {
-			return "", nil
-		}
-	} else {
-		// do not send to ourself for any other event
-		if channel.ID == getChannelID(rmsg) {
-			return "", nil
-		}
-	}
-
-	// Only send irc notices to irc
-	if msg.Event == config.EventNoticeIRC && dest.Protocol != "irc" {
-		return "", nil
-	}
-
-	// Too noisy to log like other events
-	debugSendMessage := ""
-	if msg.Event != config.EventUserTyping {
-		debugSendMessage = fmt.Sprintf("=> Sending %#v from %s (%s) to %s (%s)", msg, msg.Account, rmsg.Channel, dest.Account, channel.Name)
-	}
-
-	msg.Channel = channel.Name
-	msg.Avatar = gw.modifyAvatar(rmsg, dest)
-	msg.Username = gw.modifyUsername(rmsg, dest)
-
-	// exclude file delete event as the msg ID here is the native file ID that needs to be deleted
-	if msg.Event != config.EventFileDelete {
-		msg.ID = gw.getDestMsgID(rmsg.Protocol+" "+rmsg.ID, dest, channel)
-	}
-
-	// for api we need originchannel as channel
-	if dest.Protocol == apiProtocol {
-		msg.Channel = rmsg.Channel
-	}
-
-	msg.ParentID = gw.getDestMsgID(canonicalParentMsgID, dest, channel)
-	if msg.ParentID == "" {
-		msg.ParentID = strings.Replace(canonicalParentMsgID, dest.Protocol+" ", "", 1)
-	}
-
-	// if the parentID is still empty and we have a parentID set in the original message
-	// this means that we didn't find it in the cache so set it to a "msg-parent-not-found" constant
-	if msg.ParentID == "" && rmsg.ParentID != "" {
-		msg.ParentID = config.ParentIDNotFound
-	}
-
-	drop, err := gw.modifyOutMessageTengo(rmsg, &msg, dest)
-	if err != nil {
-		gw.logger.Errorf("modifySendMessageTengo: %s", err)
-	}
-
-	if drop {
-		gw.logger.Debugf("=> Tengo dropping %#v from %s (%s) to %s (%s)", msg, msg.Account, rmsg.Channel, dest.Account, channel.Name)
-		return "", nil
-	}
-
-	if debugSendMessage != "" {
-		gw.logger.Debug(debugSendMessage)
-	}
-	// if we are using mattermost plugin account, send messages to MattermostPlugin channel
-	// that can be picked up by the mattermost matterbridge plugin
-	if dest.Account == "mattermost.plugin" {
-		gw.Router.MattermostPlugin <- msg
-	}
-
-	defer func(t time.Time) {
-		gw.logger.Debugf("=> Send from %s (%s) to %s (%s) took %s", msg.Account, rmsg.Channel, dest.Account, channel.Name, time.Since(t))
-	}(time.Now())
-
-	mID, err := dest.Send(msg)
-	if err != nil {
-		return mID, err
-	}
-
-	// append the message ID (mID) from this bridge (dest) to our brMsgIDs slice
-	if mID != "" {
-		gw.logger.Debugf("mID %s: %s", dest.Account, mID)
-		return mID, nil
-		// brMsgIDs = append(brMsgIDs, &BrMsgID{dest, dest.Protocol + " " + mID, channel.ID})
-	}
-	return "", nil
 }
 
 func (gw *Gateway) validGatewayDest(msg *config.Message) bool {


### PR DESCRIPTION
Squashed version of previous PR ([#214](https://github.com/matterbridge-org/matterbridge/pull/214)), without the accidentally merged XMPP commits.

This will colorize different fields of the `RemoteNickFormat` string separately (e.g. label, protocol, nick, channel, etc.). This only functions when there are spaces in the format which separate the fields.

This allows for the same nick, label, or other space-separated field to have a consistent color, no matter what other fields are included in the string.

Incoming messages from bridges that allow spaces in the nicknames (such as Discord or XMPP) will have any such spaces replaced with non-breaking spaces (NBSP), which are then ignored by the `Colornicks` logic.

In order to avoid mangling such nicks for any subsequent bridges, something like (https://github.com/42wim/matterbridge/pull/2044) should probably be considered.

To work around the current possibility that such prior mangling has occurred, the `sanitizeNick` function has been updated to also filter NBSP's from the nick when `UseRelayMsg` is set.