### PR TITLE
fix: Check for valid utf-8 before autodetecting incoming charset on irc (#120)

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -360,6 +360,7 @@ func NewConfigFromString(rootLogger *logrus.Logger, input []byte) Config {
 func newConfigFromString(logger *logrus.Entry, input []byte, cfgtype string) *config {
 	viper.SetConfigType(cfgtype)
 	viper.SetDefault("General.RemoteNickFormat", "[{PROTOCOL}] <{NICK}> ") // fixes #162
+	viper.SetDefault("General.Charset", "utf-8")                           // fixes #120 (it's irc-only, but shouldn't hurt to put it here)
 	viper.SetEnvPrefix("matterbridge")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/lrstanley/girc"
 	"github.com/matterbridge-org/matterbridge/bridge/config"
@@ -19,16 +20,25 @@ import (
 	_ "github.com/paulrosania/go-charset/data"
 )
 
+// this handler actually gets called when sending out to an IRC bridge, not when receiving a privmsg via the irc library.
+// refer to handlePrivMsg() for the latter (including attempted autodetection when no charset is specified)
+//
+// If we received the message from another IRC bridge, the text should have already been converted to UTF-8.
+// If from any other bridge type, no conversion is needed, as all other supported bridge types use UTF-8 exclusively.
+//
+// TODO: rework this using x/text/transform and x/text/encoding packages instead of go-charset
 func (b *Birc) handleCharset(msg *config.Message) error {
 	if b.GetString("Charset") != "" {
 		switch b.GetString("Charset") {
-		case "gbk", "gb18030", "gb2312", "big5", "euc-kr", "euc-jp", "shift-jis", "iso-2022-jp":
-			msg.Text = toUTF8(b.GetString("Charset"), msg.Text)
+		//case "gbk", "gb18030", "gb2312", "big5", "euc-kr", "euc-jp", "shift-jis", "iso-2022-jp":
+		//	msg.Text = toUTF8(b.GetString("Charset"), msg.Text)
+		case "utf8", "utf-8":
+			break
 		default:
 			buf := new(bytes.Buffer)
 			w, err := charset.NewWriter(b.GetString("Charset"), buf)
 			if err != nil {
-				b.Log.Errorf("charset to utf-8 conversion failed: %s", err)
+				b.Log.Errorf("utf-8 to charset conversion failed: %s", err)
 				return err
 			}
 			fmt.Fprint(w, msg.Text)
@@ -238,12 +248,12 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 		rmsg.Event = config.EventNoticeIRC
 	}
 
-	// strip action, we made an event if it was an action
-	rmsg.Text += event.StripAction()
+	// trailing param is message content.  we'll treat it as a byte slice first, convert to utf-8 if needed, then do our own version of StripAction
+	rmsg.Text = event.Params[len(event.Params)-1]
 
 	// start detecting the charset
 	mycharset := b.GetString("Charset")
-	if mycharset == "" {
+	if mycharset == "" && !utf8.Valid([]byte(rmsg.Text)) { // check for valid utf-8 before any other checks
 		// detect what were sending so that we convert it to utf-8
 		detector := chardet.NewTextDetector()
 		result, err := detector.DetectBest([]byte(rmsg.Text))
@@ -257,10 +267,16 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 		if result.Confidence < 80 {
 			mycharset = "ISO-8859-1"
 		}
+	} else {
+		mycharset = "utf-8" // fixes #120 (mostly)
 	}
 	switch mycharset {
 	case "gbk", "gb18030", "gb2312", "big5", "euc-kr", "euc-jp", "shift-jis", "iso-2022-jp":
-		rmsg.Text = toUTF8(b.GetString("Charset"), rmsg.Text)
+		// wait a sec, why were we calling b.GetString() again when it might be empty?
+		//rmsg.Text = toUTF8(b.GetString("Charset"), rmsg.Text)
+		rmsg.Text = toUTF8(mycharset, rmsg.Text)
+	case "utf8", "utf-8":
+		break
 	default:
 		r, err := charset.NewReader(mycharset, strings.NewReader(rmsg.Text))
 		if err != nil {
@@ -270,6 +286,13 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 
 		output, _ := io.ReadAll(r)
 		rmsg.Text = string(output)
+	}
+	
+	// let's make sure only to modify the message text AFTER the possible utf-8 conversion.
+	// strip action, we made an event if it was an action
+	//rmsg.Text += event.StripAction()
+	if event.IsAction() {
+		rmsg.Text = rmsg.Text[8 : len(rmsg.Text)-1]
 	}
 
 	b.Log.Debugf("<= Sending message from %s on %s to gateway", event.Params[0], b.Account)

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -20,6 +20,8 @@ import (
 	_ "github.com/paulrosania/go-charset/data"
 )
 
+const utf8charset = "utf-8"
+
 // this handler actually gets called when sending out to an IRC bridge, not when receiving a privmsg via the irc library.
 // refer to handlePrivMsg() for the latter (including attempted autodetection when no charset is specified)
 //
@@ -28,11 +30,9 @@ import (
 //
 // TODO: rework this using x/text/transform and x/text/encoding packages instead of go-charset
 func (b *Birc) handleCharset(msg *config.Message) error {
-	if b.GetString("Charset") != "" {
+	if b.GetString("Charset") != "autodetect" {
 		switch b.GetString("Charset") {
-		//case "gbk", "gb18030", "gb2312", "big5", "euc-kr", "euc-jp", "shift-jis", "iso-2022-jp":
-		//	msg.Text = toUTF8(b.GetString("Charset"), msg.Text)
-		case "utf8", "utf-8":
+		case "utf8", utf8charset:
 			break
 		default:
 			buf := new(bytes.Buffer)
@@ -253,7 +253,7 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 
 	// start detecting the charset
 	mycharset := b.GetString("Charset")
-	if mycharset == "" && !utf8.Valid([]byte(rmsg.Text)) { // check for valid utf-8 before any other checks
+	if mycharset == "autodetect" && !utf8.ValidString(rmsg.Text) { // check for valid utf-8 before any other checks
 		// detect what were sending so that we convert it to utf-8
 		detector := chardet.NewTextDetector()
 		result, err := detector.DetectBest([]byte(rmsg.Text))
@@ -268,14 +268,12 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 			mycharset = "ISO-8859-1"
 		}
 	} else {
-		mycharset = "utf-8" // fixes #120 (mostly)
+		mycharset = utf8charset // fixes #120 (mostly)
 	}
 	switch mycharset {
 	case "gbk", "gb18030", "gb2312", "big5", "euc-kr", "euc-jp", "shift-jis", "iso-2022-jp":
-		// wait a sec, why were we calling b.GetString() again when it might be empty?
-		//rmsg.Text = toUTF8(b.GetString("Charset"), rmsg.Text)
 		rmsg.Text = toUTF8(mycharset, rmsg.Text)
-	case "utf8", "utf-8":
+	case "utf8", utf8charset:
 		break
 	default:
 		r, err := charset.NewReader(mycharset, strings.NewReader(rmsg.Text))
@@ -287,10 +285,9 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 		output, _ := io.ReadAll(r)
 		rmsg.Text = string(output)
 	}
-	
+
 	// let's make sure only to modify the message text AFTER the possible utf-8 conversion.
 	// strip action, we made an event if it was an action
-	//rmsg.Text += event.StripAction()
 	if event.IsAction() {
 		rmsg.Text = rmsg.Text[8 : len(rmsg.Text)-1]
 	}

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -156,11 +156,6 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		b.Command(&msg)
 	}
 
-	// convert to specified charset
-	if err := b.handleCharset(&msg); err != nil {
-		return "", err
-	}
-
 	// handle files, return if we're done here
 	if ok := b.handleFiles(&msg); ok {
 		return "", nil
@@ -183,6 +178,13 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		}
 
 		msg.Text = msgLines[i]
+
+		// convert to specified charset
+		err := b.handleCharset(&msg)
+		if err != nil {
+			b.Log.Warn("Error converting to charset")
+		}
+
 		b.Local <- msg
 	}
 	return "", nil

--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,7 @@
   - when an attachment has no public URL, an error message is printed/logged encouraging the
     matterbridge operator to enable the mediaserver, instead of producing an incoherent message
     ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
+  - prior to attempting automatic charset detection, check whether the message is valid UTF-8.  this should mostly fix ([#120](https://github.com/matterbridge-org/matterbridge/issues/120)) but some improvements are still needed.
 
 ## Upstream
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 - irc: Leading colon messages are no longer doubled by default as an undocumented hack (eg `:D` -> `::D`); it's now enabled by the `DoubleColonPrefix` setting.
   If you are using this setting please help us understand the usecase by commenting
   on [issue #122](https://github.com/matterbridge-org/matterbridge/issues/122), otherwise this setting may be deprecated in the near-future.
+- irc: Charset for irc bridges will now be set to a default of "UTF-8", to avoid mojibake when attempting to automatically guess the incoming charset.  If you want to try autodetecting, you will need to set this to "autodetect" for the irc bridge.  Ideally, you will know which charset to set and won't have to try to guess.  Even with autodetection set, UTF-8 will be checked first before trying anything else, then fall back to latin-1 if the autodetection fails.  This should mostly address ([#120](https://github.com/matterbridge-org/matterbridge/issues/120))
 
 ## New Features
 
@@ -49,7 +50,7 @@
   - legacy `whatsapp` backend has been deprecated in favor of `whatsappmulti` ([#32](https://github.com/matterbridge-org/matterbridge/issues/32)) ; this is not a breaking change and will not affect your existing settings
 - slack
   - added support for using socket mode Events API to receive messages for bridging instead of RTM.
-    this allows new slack bridge to be set up using modern slack apps and its tokens; see the slack docs for setup instructions ([#149](https://github.com/matterbridge-org/matterbridge/pull/149)).  
+    this allows new slack bridge to be set up using modern slack apps and its tokens; see the slack docs for setup instructions ([#149](https://github.com/matterbridge-org/matterbridge/pull/149)).
     note that the existing slack bridge setup using bot token with _classic_ slack apps should continue to work as before, until slack decides to turn off RTM system.
 
 ## Bugfixes
@@ -82,7 +83,6 @@
   - when an attachment has no public URL, an error message is printed/logged encouraging the
     matterbridge operator to enable the mediaserver, instead of producing an incoherent message
     ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
-  - prior to attempting automatic charset detection, check whether the message is valid UTF-8.  this should mostly fix ([#120](https://github.com/matterbridge-org/matterbridge/issues/120)) but some improvements are still needed.
 
 ## Upstream
 

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -47,7 +47,10 @@ SkipTLSVerify=true
 Bind=""
 
 #If you know your charset, you can specify it manually.
-#Otherwise it tries to detect this automatically. Select one below
+#Otherwise, the default is UTF-8.  If you want to attempt to detect this automatically,
+#set it to "autodetect".
+# You can choose one of the following:
+#
 # "iso-8859-2:1987", "iso-8859-9:1989", "866", "latin9", "iso-8859-10:1992", "iso-ir-109", "hebrew",
 # "cp932", "iso-8859-15", "cp437", "utf-16be", "iso-8859-3:1988", "windows-1251", "utf16", "latin6",
 # "latin3", "iso-8859-1:1987", "iso-8859-9", "utf-16le", "big5", "cp819", "asmo-708", "utf-8",
@@ -58,10 +61,10 @@ Bind=""
 # "windows-1252", "l2", "koi8-r", "iso8859-1", "latin1", "ecma-114", "iso-ir-110", "elot-928",
 # "iso-ir-126", "iso-8859-1", "iso-ir-127", "cp850", "cyrillic", "greek8", "windows-1250", "iso-latin-1",
 # "l5", "ibm866", "cp866", "ms-kanji", "ibm850", "ecma-118", "iso-ir-101", "ibm819", "l1", "iso-8859-6:1987",
-# "latin5", "ascii", "sjis", "iso-8859-10", "iso-8859-4", "iso-8859-4:1988", "shift-jis
-# The select charset will be converted to utf-8 when sent to other bridges.
-#OPTIONAL (default "")
-Charset=""
+# "latin5", "ascii", "sjis", "iso-8859-10", "iso-8859-4", "iso-8859-4:1988", "shift-jis, "autodetect"
+# The selected charset will be converted to utf-8 when sent to other bridges.
+#OPTIONAL (default "utf-8")
+Charset="utf-8"
 
 #Your nick on irc.
 #REQUIRED


### PR DESCRIPTION
Fix for ([#120](https://github.com/matterbridge-org/matterbridge/issues/120))

Additional changes in this commit:

- Repaired `handleCharset()` which previously seemed confused whether it was being called on bridge input or output.  it still needs work

- Relocated and reimplemented the girc `event.StripAction` call to post-`chardet` section in `handlePrivMsg()` so as not to risk prematurely treating the message text as utf-8

- Commented out and replaced a potentially dangerous `b.GetString("Charset")` call after it had already been checked and found potentially empty a few lines prior
