### PR TITLE
Update `rmsg` avatar and user ID fields in Discord.

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -146,7 +146,7 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 		return
 	}
 
-	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".webp", UserID: m.Author.Username, ID: m.ID, Extra: make(map[string][]interface{})}
+	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".webp", UserID: "@" + m.Author.Username, ID: m.ID, Extra: make(map[string][]interface{})}
 
 	b.Log.Debugf("== Receiving event %#v", m.Message)
 

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -146,7 +146,7 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 		return
 	}
 
-	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".jpg", UserID: m.Author.ID, ID: m.ID, Extra: make(map[string][]interface{})}
+	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".webp", UserID: m.Author.Username, ID: m.ID, Extra: make(map[string][]interface{})}
 
 	b.Log.Debugf("== Receiving event %#v", m.Message)
 

--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,7 @@
   - attached files are always downloaded, so when the media server is enabled, URLs can stay valid
     longer than Discord URLs ([#37](https://github.com/matterbridge-org/matterbridge/issues/37), [#114](https://github.com/matterbridge-org/matterbridge/pull/114))
   - all users in a guild are considered for name lookup instead of only a subset of 1000 ([#198](https://github.com/matterbridge-org/matterbridge/pull/198))
+  - discord now sets `{USERID}` in a `RemoteNickFormat` to the username rather than the actual user ID ([#225](https://github.com/matterbridge-org/matterbridge/pull/225))
 - irc
   - when there are attachments in the message, the body is now sent instead of being discarded silently ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
   - when an attachment has no public URL, an error message is printed/logged encouraging the


### PR DESCRIPTION
only did this because it was a pain seeing a mess of numbers rather than the actual username... also (debatably) fixes #183 because this will make that possible