### PR TITLE
partially revert #225

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -146,7 +146,7 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 		return
 	}
 
-	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".webp", UserID: "@" + m.Author.Username, ID: m.ID, Extra: make(map[string][]interface{})}
+	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".jpg", UserID: "@" + m.Author.Username, ID: m.ID, Extra: make(map[string][]interface{})} // here we use .jpg over .webp for wider support across bridges and clients in general. discord automatically converts as needed anyhow.
 
 	b.Log.Debugf("== Receiving event %#v", m.Message)
 


### PR DESCRIPTION
> In the matterbridge channel:
> [LC] <unicron> Swirly: looks like discord avatars can be uploaded as jpg, png, or webp. discord stores them as webp internally and converts them automatically when another format is requested for download. Can you please check whether all the other bridges which support avatars also support webp, otherwise probably better to revert to requesting the jpg instead?