### PR TITLE
rocketchat: do not try to impersonate user if not required

### DIFF
--- a/bridge/rocketchat/rocketchat.go
+++ b/bridge/rocketchat/rocketchat.go
@@ -151,10 +151,12 @@ func (b *Brocketchat) Send(msg config.Message) (string, error) {
 			smsg := &models.Message{
 				RoomID: b.getChannelID(rmsg.Channel),
 				Msg:    rmsg.Username + rmsg.Text,
-				PostMessage: models.PostMessage{
+			}
+			if !b.GetBool("PrefixMessagesWithNick") {
+				smsg.PostMessage = models.PostMessage{
 					Avatar: rmsg.Avatar,
 					Alias:  rmsg.Username,
-				},
+				}
 			}
 			if _, err := b.c.SendMessage(smsg); err != nil {
 				b.Log.Errorf("SendMessage failed: %s", err)
@@ -168,10 +170,12 @@ func (b *Brocketchat) Send(msg config.Message) (string, error) {
 	smsg := &models.Message{
 		RoomID: channel.ID,
 		Msg:    msg.Text,
-		PostMessage: models.PostMessage{
+	}
+	if !b.GetBool("PrefixMessagesWithNick") {
+		smsg.PostMessage = models.PostMessage{
 			Avatar: msg.Avatar,
 			Alias:  msg.Username,
-		},
+		}
 	}
 
 	rmsg, err := b.c.SendMessage(smsg)


### PR DESCRIPTION
rocketchat: do NOT try to impersonate user if PrefixMessagesWithNick=true, this should partially fix #153
    
Sending Alias and Avatar unconditionally causes a "Match failed" 400 error
on RocketChat servers where the bot role does not have the message-impersonate
permission. Only send these fields when PrefixMessagesWithNick is false.
    
Fixes #153
Ref: https://github.com/matterbridge-org/matterbridge/issues/153
