### PR TITLE
fix(irc): include kicked nick + reason in KICK event relay

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -134,13 +134,9 @@ func (b *Birc) handleJoinPart(client *girc.Client, event girc.Event) {
 		if b.GetBool("nosendjoinpart") {
 			return
 		}
-		msg := config.Message{Username: "system", Text: event.Source.Name + " " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
-		if b.GetBool("verbosejoinpart") {
-			b.Log.Debugf("<= Sending verbose JOIN_LEAVE event from %s to gateway", b.Account)
-			msg = config.Message{Username: "system", Text: event.Source.Name + " (" + event.Source.Ident + "@" + event.Source.Host + ") " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
-		} else {
-			b.Log.Debugf("<= Sending JOIN_LEAVE event from %s to gateway", b.Account)
-		}
+		text := formatJoinLeaveText(event, b.GetBool("verbosejoinpart"))
+		msg := config.Message{Username: "system", Text: text, Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
+		b.Log.Debugf("<= Sending JOIN_LEAVE event from %s to gateway", b.Account)
 		b.Log.Debugf("<= Message is %#v", msg)
 		b.Remote <- msg
 		return
@@ -343,4 +339,22 @@ func (b *Birc) handleTopicWhoTime(client *girc.Client, event girc.Event) {
 		user += " [" + parts[1] + "]"
 	}
 	b.Log.Debugf("%s: Topic set by %s [%s]", event.Command, user, time.Unix(t, 0))
+}
+
+// formatJoinLeaveText renders a join/part/quit/kick event into a human-readable
+// system message. Special-cases KICK so the kicked nick (and reason, if any)
+// appear instead of just "<kicker> kicks".
+func formatJoinLeaveText(event girc.Event, verbose bool) string {
+	source := event.Source.Name
+	if verbose && event.Source.Ident != "" {
+		source += " (" + event.Source.Ident + "@" + event.Source.Host + ")"
+	}
+	if event.Command == "KICK" && len(event.Params) >= 2 {
+		text := source + " kicked " + event.Params[1]
+		if reason := event.Last(); reason != "" && reason != event.Params[1] {
+			text += " (" + reason + ")"
+		}
+		return text
+	}
+	return source + " " + strings.ToLower(event.Command) + "s"
 }

--- a/bridge/irc/handlers_test.go
+++ b/bridge/irc/handlers_test.go
@@ -1,0 +1,67 @@
+package birc
+
+import (
+	"testing"
+
+	"github.com/lrstanley/girc"
+)
+
+func TestFormatJoinLeaveText(t *testing.T) {
+	src := func(name, ident, host string) *girc.Source {
+		return &girc.Source{Name: name, Ident: ident, Host: host}
+	}
+
+	cases := []struct {
+		name    string
+		event   girc.Event
+		verbose bool
+		want    string
+	}{
+		{
+			name:  "join",
+			event: girc.Event{Source: src("alice", "alice", "host"), Command: "JOIN", Params: []string{"#chan"}},
+			want:  "alice joins",
+		},
+		{
+			name:  "part",
+			event: girc.Event{Source: src("alice", "alice", "host"), Command: "PART", Params: []string{"#chan"}},
+			want:  "alice parts",
+		},
+		{
+			name:  "quit",
+			event: girc.Event{Source: src("alice", "alice", "host"), Command: "QUIT", Params: []string{"Bye"}},
+			want:  "alice quits",
+		},
+		{
+			name:  "kick with reason",
+			event: girc.Event{Source: src("vjt", "vjt", "host"), Command: "KICK", Params: []string{"#chan", "alice", "spam"}},
+			want:  "vjt kicked alice (spam)",
+		},
+		{
+			name:  "kick without reason",
+			event: girc.Event{Source: src("vjt", "vjt", "host"), Command: "KICK", Params: []string{"#chan", "alice"}},
+			want:  "vjt kicked alice",
+		},
+		{
+			name:    "verbose join",
+			event:   girc.Event{Source: src("alice", "alice", "host.example"), Command: "JOIN", Params: []string{"#chan"}},
+			verbose: true,
+			want:    "alice (alice@host.example) joins",
+		},
+		{
+			name:    "verbose kick",
+			event:   girc.Event{Source: src("vjt", "vjt", "host.example"), Command: "KICK", Params: []string{"#chan", "alice", "bye"}},
+			verbose: true,
+			want:    "vjt (vjt@host.example) kicked alice (bye)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatJoinLeaveText(c.event, c.verbose)
+			if got != c.want {
+				t.Errorf("formatJoinLeaveText() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/changelog.md
+++ b/changelog.md
@@ -91,6 +91,9 @@
   - when an attachment has no public URL, an error message is printed/logged encouraging the
     matterbridge operator to enable the mediaserver, instead of producing an incoherent message
     ([#156](https://github.com/matterbridge-org/matterbridge/pull/156))
+  - KICK events now relay the kicked nick and the kick reason, instead of showing up downstream
+    as a bare join/leave-style line with no indication of who was kicked or why
+    ([#240](https://github.com/matterbridge-org/matterbridge/pull/240))
 
 ## Upstream
 


### PR DESCRIPTION
The IRC bridge relays KICK events without the kicked target or the kick reason, so a kick shows up downstream as a bare join/leave-style line with no indication of who was kicked or why.

This includes the kicked nick and reason in the KICK event relay (via `formatJoinLeaveText`), with a unit test covering the KICK target/reason formatting.

Two commits: the fix and its test. Cleanly applies on current `master`; `go build ./bridge/irc/` and `go test ./bridge/irc/` pass.

Re-homed from 42wim/matterbridge#2254 — opening here since matterbridge-org is the actively maintained fork.