### PR TITLE
fix slack: files downloads over socket mode by fetching full file info

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -502,6 +502,19 @@ func (b *Bslack) handleDownloadFile(rmsg *config.Message, file *slack.File, retr
 	if b.fileCached(file) {
 		return nil
 	}
+
+	// Files attached to events received over the socket mode Events API are
+	// "lite" objects without download URLs, so we have to fetch the full
+	// file object first. See https://github.com/matterbridge-org/matterbridge/issues/241
+	// and https://docs.slack.dev/reference/events/file_shared/#usage-info
+	if file.URLPrivateDownload == "" {
+		fullFile, _, _, err := b.sc.GetFileInfo(file.ID, 0, 0)
+		if err != nil {
+			return fmt.Errorf("GetFileInfo for file %s failed: %w", file.ID, err)
+		}
+		file = fullFile
+	}
+
 	// Check that the file is neither too large nor blacklisted.
 	if err := helper.HandleDownloadSize(b.Log, rmsg, file.Name, int64(file.Size), b.General); err != nil {
 		b.Log.WithError(err).Infof("Skipping download of incoming file.")

--- a/changelog.md
+++ b/changelog.md
@@ -86,6 +86,9 @@
   - attachments of mixed types in the same message will be uploaded as documents
 - slack
   - file uploading now use the new upload steps described in the slack docs via `UploadFileV2`, replacing the deprecated and now disabled `file.upload` based method (via `UploadFile`) ([#129](https://github.com/matterbridge-org/matterbridge/pull/129))
+  - file and image downloads now work with Socket Mode apps: the Events API delivers file objects
+    without download URLs, so the full file object is now fetched via `files.info` before
+    downloading ([#245](https://github.com/matterbridge-org/matterbridge/pull/245))
 - discord
   - attached files are always downloaded, so when the media server is enabled, URLs can stay valid
     longer than Discord URLs ([#37](https://github.com/matterbridge-org/matterbridge/issues/37), [#114](https://github.com/matterbridge-org/matterbridge/pull/114))


### PR DESCRIPTION
With new Slack apps using Socket Mode (Events API), text messages bridge fine, but any shared file/image fails to transfer. The problem was described in issue #241 

In `handleDownloadFile()`, when `file.URLPrivateDownload` is empty, fetch the complete file object via `files.info` (`GetFileInfo`, already used elsewhere in this bridge) and proceed with that. This also repairs the file-size check, which relied on the same lite object

This fix has only been tested between Slack and Mattermost. However, since the issue was specifically on the Slack bridge side, the solution should be reproducible with any bridge